### PR TITLE
cleanup: simplify action status insertion

### DIFF
--- a/internal/infrastructure/sqlite/fin.go
+++ b/internal/infrastructure/sqlite/fin.go
@@ -111,13 +111,13 @@ func (fr *FinRepository) StartOrRestartAction(uid string, action model.ActionKin
 	}
 
 	if !foundMyEntry {
-		stmt, err := tx.Prepare("INSERT INTO action_status VALUES(?, ?, ?, ?, ?)")
+		stmt, err := tx.Prepare("INSERT INTO action_status (uid, action) VALUES(?, ?)")
 		if err != nil {
 			return err
 		}
 		defer func() { _ = stmt.Close() }()
 
-		_, err = stmt.Exec(uid, action, nil, time.Now(), nil)
+		_, err = stmt.Exec(uid, action)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We can omit 3rd, 4th, and 5th placeholders because the appropriate values will be set for the corresponding columns by default.