### PR TITLE
job: add partSize field to backup_metadata

### DIFF
--- a/internal/job/backup/backup.go
+++ b/internal/job/backup/backup.go
@@ -316,6 +316,7 @@ func (b *Backup) declareStoringCompleted(targetSnapshot *model.RBDSnapshot) erro
 	metadata.Diff[0].SnapID = targetSnapshot.ID
 	metadata.Diff[0].SnapName = targetSnapshot.Name
 	metadata.Diff[0].SnapSize = targetSnapshot.Size
+	metadata.Diff[0].PartSize = b.maxPartSize
 	metadata.Diff[0].CreatedAt = createdAt
 
 	return job.SetBackupMetadata(b.repo, metadata)
@@ -368,6 +369,7 @@ func (b *Backup) declareFullBackupApplicationCompleted(targetSnapshot *model.RBD
 		SnapID:    targetSnapshot.ID,
 		SnapName:  targetSnapshot.Name,
 		SnapSize:  targetSnapshot.Size,
+		PartSize:  b.maxPartSize,
 		CreatedAt: createdAt,
 	}
 

--- a/internal/job/backup/backup_test.go
+++ b/internal/job/backup/backup_test.go
@@ -139,6 +139,7 @@ func TestFullBackup_Success(t *testing.T) {
 	assert.Equal(t, targetSnapshotID, metadata.Raw.SnapID)
 	assert.Equal(t, targetSnapshotName, metadata.Raw.SnapName)
 	assert.Equal(t, targetSnapshotSize, metadata.Raw.SnapSize)
+	assert.Equal(t, maxPartSize, metadata.Raw.PartSize)
 	assert.Equal(t, targetSnapshotTimestamp, metadata.Raw.CreatedAt.Format(time.ANSIC))
 	assert.Empty(t, metadata.Diff)
 }
@@ -282,12 +283,14 @@ func TestIncrementalBackup_Success(t *testing.T) {
 	assert.Equal(t, previousSnapshotID, metadata.Raw.SnapID)
 	assert.Equal(t, previousSnapshotName, metadata.Raw.SnapName)
 	assert.Equal(t, previousSnapshotSize, metadata.Raw.SnapSize)
+	assert.Equal(t, maxPartSize, metadata.Raw.PartSize)
 	assert.Equal(t, previousSnapshotTimestamp, metadata.Raw.CreatedAt.Format(time.ANSIC))
 	assert.NotNil(t, metadata.Diff)
 	assert.Len(t, metadata.Diff, 1)
 	assert.Equal(t, targetSnapshotID, metadata.Diff[0].SnapID)
 	assert.Equal(t, targetSnapshotName, metadata.Diff[0].SnapName)
 	assert.Equal(t, targetSnapshotSize, metadata.Diff[0].SnapSize)
+	assert.Equal(t, maxPartSize, metadata.Diff[0].PartSize)
 	assert.Equal(t, targetSnapshotTimestamp, metadata.Diff[0].CreatedAt.Format(time.ANSIC))
 }
 

--- a/internal/job/util.go
+++ b/internal/job/util.go
@@ -45,6 +45,7 @@ type BackupMetadataEntry struct {
 	SnapID    int       `json:"snapID"`
 	SnapName  string    `json:"snapName"`
 	SnapSize  int       `json:"snapSize"`
+	PartSize  int       `json:"partSize"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 


### PR DESCRIPTION
- Separate the one package for jobs to the utility package and each job.
- Add partSize field to backup_metadata table. It's necessary to implement some jobs.