### PR TITLE
job: implement restore job

### DIFF
--- a/internal/infrastructure/fake/restore.go
+++ b/internal/infrastructure/fake/restore.go
@@ -3,11 +3,12 @@ package fake
 import (
 	"fmt"
 
+	r "github.com/cybozu-go/fin/internal/infrastructure/restore"
 	"github.com/cybozu-go/fin/internal/model"
 )
 
 type restoreRepository struct {
-	path         string
+	real         *r.RestoreRepository
 	appliedDiffs []*ExportedDiff
 }
 
@@ -17,7 +18,7 @@ func NewRestoreRepository(
 	path string,
 ) *restoreRepository {
 	return &restoreRepository{
-		path:         path,
+		real:         r.NewRestoreRepository(path),
 		appliedDiffs: make([]*ExportedDiff, 0),
 	}
 }
@@ -35,7 +36,7 @@ func (r *restoreRepository) ApplyDiff(diffFilePath string) error {
 }
 
 func (r *restoreRepository) GetPath() string {
-	return r.path
+	return r.real.GetPath()
 }
 
 func (r *restoreRepository) BlkDiscard() error {
@@ -44,4 +45,8 @@ func (r *restoreRepository) BlkDiscard() error {
 
 func (r *restoreRepository) AppliedDiffs() []*ExportedDiff {
 	return r.appliedDiffs
+}
+
+func (r *restoreRepository) CopyChunk(rawPath string, index int, chunkSize int64) error {
+	return r.real.CopyChunk(rawPath, index, chunkSize)
 }

--- a/internal/infrastructure/nlv/nlv.go
+++ b/internal/infrastructure/nlv/nlv.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/cybozu-go/fin/internal/model"
@@ -30,6 +31,10 @@ func (r *NodeLocalVolumeRepository) Cleanup() {
 
 func (r *NodeLocalVolumeRepository) GetRootPath() string {
 	return r.rootPath
+}
+
+func (r *NodeLocalVolumeRepository) GetRawImagePath() string {
+	return filepath.Join(r.GetRootPath(), "raw.img")
 }
 
 func (r *NodeLocalVolumeRepository) WriteFile(filePath string, data []byte) error {

--- a/internal/infrastructure/restore/restore.go
+++ b/internal/infrastructure/restore/restore.go
@@ -2,6 +2,9 @@ package restore
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"os"
 
 	"github.com/cybozu-go/fin/internal/model"
 )
@@ -28,4 +31,51 @@ func (r *RestoreRepository) BlkDiscard() error {
 
 func (r *RestoreRepository) ApplyDiff(diffPath string) error {
 	return errors.New("not implemented")
+}
+
+func (r *RestoreRepository) CopyChunk(rawPath string, index int, chunkSize int64) error {
+	rawFile, err := os.Open(rawPath)
+	if err != nil {
+		return fmt.Errorf("failed to open `%s`: %w", rawPath, err)
+	}
+	defer func() { _ = rawFile.Close() }()
+
+	resVol, err := os.OpenFile(r.GetPath(), os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open `%s`: %w", r.GetPath(), err)
+	}
+	defer func() { _ = resVol.Close() }()
+
+	if _, err := rawFile.Seek(int64(index)*chunkSize, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek `%s` to %d: %w",
+			rawPath, int64(index)*chunkSize, err)
+	}
+	if _, err = resVol.Seek(int64(index)*chunkSize, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek `%s` to %d: %w",
+			r.GetPath(), int64(index)*chunkSize, err)
+	}
+
+	buf := make([]byte, chunkSize)
+	for {
+		rn, err := rawFile.Read(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed to read: %w", err)
+		}
+
+		if rn > 0 {
+			wn, err := resVol.Write(buf[:rn])
+			if err != nil {
+				return fmt.Errorf("failed to write: %w", err)
+			}
+			if wn != rn {
+				return fmt.Errorf("short write: wrote %d bytes, expected %d", wn, rn)
+			}
+			// FIXME: calculate and store the checksum of `buf` here.
+		}
+	}
+
+	return nil
 }

--- a/internal/job/backup/backup.go
+++ b/internal/job/backup/backup.go
@@ -338,7 +338,7 @@ func (b *Backup) loopApplyDiff(privateData *backupPrivateData, targetSnapshot *m
 	partCount := int(math.Ceil(float64(targetSnapshot.Size) / float64(b.maxPartSize)))
 	for i := privateData.NextPatchPart; i < partCount; i++ {
 		if err := b.rbdRepo.ApplyDiff(
-			filepath.Join(b.nodeLocalVolumeRepo.GetRootPath(), job.GetRawImagePath()),
+			b.nodeLocalVolumeRepo.GetRawImagePath(),
 			filepath.Join(b.nodeLocalVolumeRepo.GetRootPath(), job.GetDiffPartPath(b.targetSnapshotID, i)),
 		); err != nil {
 			return fmt.Errorf("failed to apply diff: %w", err)

--- a/internal/job/backup/backup_test.go
+++ b/internal/job/backup/backup_test.go
@@ -106,7 +106,7 @@ func TestFullBackup_Success(t *testing.T) {
 	testutil.AssertActionPrivateDataIsEmpty(t, finRepo, processUID)
 	testutil.AssertDiffDirDoesNotExist(t, nlvRepo, testutil.GetDiffDirPath(targetSnapshotID))
 
-	rawImage, err := fake.ReadRawImage(filepath.Join(nlvRepo.GetRootPath(), testutil.GetRawImagePath()))
+	rawImage, err := fake.ReadRawImage(nlvRepo.GetRawImagePath())
 	assert.NoError(t, err)
 	assert.Equal(t, targetSnapshotSize, rawImage.Size)
 	assert.Equal(t, 2, len(rawImage.AppliedDiffs))

--- a/internal/job/testutil/testutil.go
+++ b/internal/job/testutil/testutil.go
@@ -29,10 +29,6 @@ func GetDiffDirPath(snapshotID int) string {
 	return filepath.Join("diff", fmt.Sprintf("%d", snapshotID))
 }
 
-func GetRawImagePath() string {
-	return "raw.img"
-}
-
 func GetFinSqlite3DSN(rootPath string) string {
 	return fmt.Sprintf("file:%s?_txlock=exclusive", filepath.Join(rootPath, "fin.sqlite3"))
 }

--- a/internal/job/util.go
+++ b/internal/job/util.go
@@ -12,10 +12,6 @@ import (
 
 var ErrCantLock = errors.New("can't lock")
 
-func GetRawImagePath() string {
-	return "raw.img"
-}
-
 func GetDiffDirPath(snapshotID int) string {
 	return filepath.Join("diff", fmt.Sprintf("%d", snapshotID))
 }

--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -9,7 +9,6 @@ import (
 type ActionKind string
 
 const (
-	// TODO: Add required actions here.
 	Backup  ActionKind = "Backup"
 	Restore ActionKind = "Restore"
 )
@@ -101,6 +100,9 @@ type NodeLocalVolumeRepository interface {
 	// GetRootPath returns the root path of the node local volume repository.
 	GetRootPath() string
 
+	// GetRawImagePath returns the path of raw.img
+	GetRawImagePath() string
+
 	// WriteFile writes data to a file at the specified path.
 	WriteFile(filePath string, data []byte) error
 
@@ -122,4 +124,7 @@ type RestoreRepository interface {
 
 	// Apply diff applies diff to the block device file
 	ApplyDiff(diffFilePath string) error
+
+	// CopyChunk copy a chunk from raw.img to the restore volume
+	CopyChunk(rawPath string, index int, chunkSize int64) error
 }


### PR DESCRIPTION
Implement the restore job to restore the backup data to the restore file corresponding to the restore target PV.

> [!NOTE]
> It's better to reduce the redundancy of test code. For instance, almost the same code for the preperation of backup
> spread over many tests. I'd like to keep this problem as is to simplify this PR. I'll create another PR for cleanup later.