### PR TITLE
job: restore: add check to vefity the target pvc id

### DIFF
--- a/internal/job/restore/restore.go
+++ b/internal/job/restore/restore.go
@@ -23,6 +23,7 @@ type Restore struct {
 	rawImageChunkSize   int64
 	targetPVCName       string
 	targetPVCNamespace  string
+	targetPVCUID        string
 }
 
 type RestoreInput struct {
@@ -36,6 +37,7 @@ type RestoreInput struct {
 	RawImageChunkSize   int64
 	TargetPVCName       string
 	TargetPVCNamespace  string
+	TargetPVCUID        string
 }
 
 func NewRestore(in *RestoreInput) *Restore {
@@ -50,6 +52,7 @@ func NewRestore(in *RestoreInput) *Restore {
 		rawImageChunkSize:   in.RawImageChunkSize,
 		targetPVCName:       in.TargetPVCName,
 		targetPVCNamespace:  in.TargetPVCNamespace,
+		targetPVCUID:        in.TargetPVCUID,
 	}
 }
 
@@ -75,6 +78,11 @@ func (r *Restore) doRestore() error {
 	metadata, err := job.GetBackupMetadata(r.repo)
 	if err != nil {
 		return fmt.Errorf("failed to get backup metadata: %w", err)
+	}
+
+	if metadata.PVCUID != r.targetPVCUID {
+		return fmt.Errorf("PVC UID in metadata table (%s) does not match the expected one (%s)",
+			metadata.PVCUID, r.targetPVCUID)
 	}
 
 	switch len(metadata.Diff) {

--- a/internal/job/restore/restore_test.go
+++ b/internal/job/restore/restore_test.go
@@ -149,6 +149,7 @@ func TestRestoreFromFullBackup_Success(t *testing.T) {
 		RawImageChunkSize:   int64(rawImageChunkSize),
 		TargetPVCName:       targetPVCName,
 		TargetPVCNamespace:  targetPVCNamespace,
+		TargetPVCUID:        targetPVCUID,
 	})
 	err = r.Perform()
 	require.NoError(t, err)
@@ -333,6 +334,7 @@ func TestRestoreFromIncrementalBackup_Success(t *testing.T) {
 		RawImageChunkSize:   int64(rawImageChunkSize),
 		TargetPVCName:       targetPVCName,
 		TargetPVCNamespace:  targetPVCNamespace,
+		TargetPVCUID:        targetPVCUID,
 	})
 	err = r.Perform()
 	require.NoError(t, err)


### PR DESCRIPTION
Target PVC UID might be changed after taking the corresponding backup. We should avoid the restoration from old backup data.