### PR TITLE
refactor(nlv): replace string-based rootPath with os.Root

### DIFF
--- a/internal/infrastructure/nlv/nlv.go
+++ b/internal/infrastructure/nlv/nlv.go
@@ -20,22 +20,22 @@ const (
 )
 
 type NodeLocalVolumeRepository struct {
-	rootPath string
+	root *os.Root
 }
 
 var _ model.NodeLocalVolumeRepository = &NodeLocalVolumeRepository{}
 
-func NewNodeLocalVolumeRepository(rootPath string) *NodeLocalVolumeRepository {
-	return &NodeLocalVolumeRepository{
-		rootPath: rootPath,
+func NewNodeLocalVolumeRepository(rootPath string) (*NodeLocalVolumeRepository, error) {
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open root directory: %w", err)
 	}
+
+	return &NodeLocalVolumeRepository{root: root}, nil
 }
 
-func (r *NodeLocalVolumeRepository) Cleanup() {
-	if r.rootPath == "" {
-		return
-	}
-	_ = os.RemoveAll(r.rootPath)
+func (r *NodeLocalVolumeRepository) Close() error {
+	return r.root.Close()
 }
 
 func getDiffRelPath(snapshotID int) string {
@@ -43,24 +43,19 @@ func getDiffRelPath(snapshotID int) string {
 }
 
 func (r *NodeLocalVolumeRepository) GetDiffPartPath(snapshotID, partIndex int) string {
-	return filepath.Join(r.rootPath, getDiffRelPath(snapshotID), fmt.Sprintf("part-%d", partIndex))
+	return filepath.Join(r.root.Name(), getDiffRelPath(snapshotID), fmt.Sprintf("part-%d", partIndex))
 }
 
 func (r *NodeLocalVolumeRepository) GetRawImagePath() string {
-	return filepath.Join(r.rootPath, "raw.img")
+	return filepath.Join(r.root.Name(), "raw.img")
 }
 
 func (r *NodeLocalVolumeRepository) GetDBPath() string {
-	return filepath.Join(r.rootPath, "fin.sqlite3")
+	return filepath.Join(r.root.Name(), "fin.sqlite3")
 }
 
 func (r *NodeLocalVolumeRepository) writeFile(filePath string, data []byte) error {
-	root, err := os.OpenRoot(r.rootPath)
-	if err != nil {
-		return fmt.Errorf("failed to open node local volume root directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-	file, err := root.Create(filePath)
+	file, err := r.root.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create or open file: %w", err)
 	}
@@ -99,13 +94,7 @@ func (r *NodeLocalVolumeRepository) PutPV(pv *corev1.PersistentVolume) error {
 //
 //nolint:dupl
 func (r *NodeLocalVolumeRepository) GetPVC() (*corev1.PersistentVolumeClaim, error) {
-	root, err := os.OpenRoot(r.rootPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open node local volume root directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-
-	f, err := root.Open(pvcFilePath)
+	f, err := r.root.Open(pvcFilePath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, model.ErrNotFound
@@ -130,13 +119,7 @@ func (r *NodeLocalVolumeRepository) GetPVC() (*corev1.PersistentVolumeClaim, err
 //
 //nolint:dupl
 func (r *NodeLocalVolumeRepository) GetPV() (*corev1.PersistentVolume, error) {
-	root, err := os.OpenRoot(r.rootPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open node local volume root directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-
-	f, err := root.Open(pvFilePath)
+	f, err := r.root.Open(pvFilePath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, model.ErrNotFound
@@ -158,16 +141,11 @@ func (r *NodeLocalVolumeRepository) GetPV() (*corev1.PersistentVolume, error) {
 }
 
 func (r *NodeLocalVolumeRepository) MakeDiffDir(snapshotID int) error {
-	root, err := os.OpenRoot(r.rootPath)
-	if err != nil {
-		return fmt.Errorf("failed to open node local volume root directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-
-	if err := root.Mkdir("diff", 0755); err != nil && !errors.Is(err, fs.ErrExist) {
+	if err := r.root.Mkdir("diff", 0755); err != nil && !errors.Is(err, fs.ErrExist) {
 		return fmt.Errorf("failed to create base diff directory 'diff': %w", err)
 	}
-	if err := root.Mkdir(getDiffRelPath(snapshotID), 0755); err != nil {
+
+	if err := r.root.Mkdir(getDiffRelPath(snapshotID), 0755); err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return model.ErrAlreadyExists
 		}
@@ -177,14 +155,8 @@ func (r *NodeLocalVolumeRepository) MakeDiffDir(snapshotID int) error {
 }
 
 func (r *NodeLocalVolumeRepository) RemoveDiffDirRecursively(snapshotID int) error {
-	root, err := os.OpenRoot(r.rootPath)
-	if err != nil {
-		return fmt.Errorf("failed to open root directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-
 	entries := []string{}
-	if err := fs.WalkDir(root.FS(), getDiffRelPath(snapshotID), func(path string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(r.root.FS(), getDiffRelPath(snapshotID), func(path string, d fs.DirEntry, err error) error {
 		entries = append(entries, path)
 		return nil
 	}); err != nil {
@@ -195,7 +167,7 @@ func (r *NodeLocalVolumeRepository) RemoveDiffDirRecursively(snapshotID int) err
 	slices.Reverse(entries)
 
 	for _, entry := range entries {
-		if err := root.Remove(entry); err != nil {
+		if err := r.root.Remove(entry); err != nil {
 			return fmt.Errorf("failed to remove entry %s: %w", entry, err)
 		}
 	}

--- a/internal/job/testutil/testutil.go
+++ b/internal/job/testutil/testutil.go
@@ -81,17 +81,17 @@ func AssertActionPrivateDataIsEmpty(t *testing.T, finRepo model.FinRepository, p
 func CreateNLVAndFinRepoForTest(t *testing.T) (*nlv.NodeLocalVolumeRepository, model.FinRepository) {
 	t.Helper()
 
-	rootPath, err := os.MkdirTemp("", "fin-fake-nlv")
+	tempDir := t.TempDir()
+	nlvRepo, err := nlv.NewNodeLocalVolumeRepository(tempDir)
 	require.NoError(t, err)
-	nlv := nlv.NewNodeLocalVolumeRepository(rootPath)
-	t.Cleanup(nlv.Cleanup)
-	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_txlock=exclusive", nlv.GetDBPath()))
-	t.Cleanup(func() { _ = db.Close })
+	t.Cleanup(func() { _ = nlvRepo.Close() })
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_txlock=exclusive", nlvRepo.GetDBPath()))
+	t.Cleanup(func() { _ = db.Close() })
 	require.NoError(t, err)
 	repo, err := sqlite.New(db)
 	require.NoError(t, err)
 
-	return nlv, repo
+	return nlvRepo, repo
 }
 
 func CreateRestoreFileForTest(t *testing.T, size int64) string {

--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -124,4 +124,7 @@ type NodeLocalVolumeRepository interface {
 
 	// RemoveDiffDirRecursively removes a diff directory and its contents.
 	RemoveDiffDirRecursively(snapshotID int) error
+
+	// Close closes the NLV, rendering it unusable for further operations.
+	Close() error
 }


### PR DESCRIPTION
os.Root.Open() should be called in the constructor to detect errors early during initialization, ensuring subsequent file operations remain safe and simple.