### PR TITLE
crd: FinRestore: remove unnecessary field

### DIFF
--- a/api/v1/finrestore_types.go
+++ b/api/v1/finrestore_types.go
@@ -33,9 +33,6 @@ type FinRestoreStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// 'actionUID' specifies the unique identifier for the restore action
-	ActionUID string `json:"actionUID,omitempty"`
-
 	// 'conditions' specifies current restore conditions
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/config/crd/bases/fin.cybozu.io_finrestores.yaml
+++ b/config/crd/bases/fin.cybozu.io_finrestores.yaml
@@ -75,10 +75,6 @@ spec:
           status:
             description: FinRestoreStatus defines the observed state of FinRestore
             properties:
-              actionUID:
-                description: '''actionUID'' specifies the unique identifier for the
-                  restore action'
-                type: string
               conditions:
                 description: '''conditions'' specifies current restore conditions'
                 items:


### PR DESCRIPTION
We found FinRestore.status.actionUID is no longer necessary.