### PR TITLE
job: restore: fix termination condition of copychunk

### DIFF
--- a/internal/infrastructure/restore/restore.go
+++ b/internal/infrastructure/restore/restore.go
@@ -56,25 +56,23 @@ func (r *RestoreVolume) CopyChunk(rawPath string, index int, chunkSize int64) er
 	}
 
 	buf := make([]byte, chunkSize)
-	for {
-		rn, err := rawFile.Read(buf)
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return fmt.Errorf("failed to read: %w", err)
+	rn, err := rawFile.Read(buf)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
 		}
+		return fmt.Errorf("failed to read: %w", err)
+	}
 
-		if rn > 0 {
-			wn, err := resVol.Write(buf[:rn])
-			if err != nil {
-				return fmt.Errorf("failed to write: %w", err)
-			}
-			if wn != rn {
-				return fmt.Errorf("short write: wrote %d bytes, expected %d", wn, rn)
-			}
-			// FIXME: calculate and store the checksum of `buf` here.
+	if rn > 0 {
+		wn, err := resVol.Write(buf[:rn])
+		if err != nil {
+			return fmt.Errorf("failed to write: %w", err)
 		}
+		if wn != rn {
+			return fmt.Errorf("short write: wrote %d bytes, expected %d", wn, rn)
+		}
+		// FIXME: calculate and store the checksum of `buf` here.
 	}
 
 	return nil


### PR DESCRIPTION
Remove unnecessary `for` loop in `copyChunk()`. It results in reading all data in raw.img on the first call.