### PR TITLE
job: restore: rename BlkDiscard to ZeroOut and implement this method

### DIFF
--- a/internal/infrastructure/fake/restore.go
+++ b/internal/infrastructure/fake/restore.go
@@ -39,7 +39,7 @@ func (r *restoreVolume) GetPath() string {
 	return r.real.GetPath()
 }
 
-func (r *restoreVolume) BlkDiscard() error {
+func (r *restoreVolume) ZeroOut() error {
 	return nil
 }
 

--- a/internal/infrastructure/restore/restore.go
+++ b/internal/infrastructure/restore/restore.go
@@ -1,10 +1,12 @@
 package restore
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 
 	"github.com/cybozu-go/fin/internal/model"
 )
@@ -25,8 +27,18 @@ func (r *RestoreVolume) GetPath() string {
 	return r.path
 }
 
-func (r *RestoreVolume) BlkDiscard() error {
-	return errors.New("not implemented")
+func (r *RestoreVolume) ZeroOut() error {
+	cmd := exec.Command("blkdiscard", "-z", r.GetPath())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to zero out %s: %w: %s", r.GetPath(), err, stderr.String())
+	}
+
+	return nil
 }
 
 func (r *RestoreVolume) ApplyDiff(diffPath string) error {

--- a/internal/job/restore/restore.go
+++ b/internal/job/restore/restore.go
@@ -130,8 +130,8 @@ func (r *Restore) doDiscardPhase(privateData *restorePrivateData) error {
 	if privateData.Phase != Discard {
 		return nil
 	}
-	if err := r.restoreVol.BlkDiscard(); err != nil {
-		return fmt.Errorf("blkdiscard failed: %w", err)
+	if err := r.restoreVol.ZeroOut(); err != nil {
+		return fmt.Errorf("failed to zero out restore volume: %w", err)
 	}
 	privateData.Phase = RestoreRawImage
 	return setRestorePrivateData(r.repo, r.actionUID, privateData)

--- a/internal/model/volume.go
+++ b/internal/model/volume.go
@@ -5,8 +5,8 @@ type RestoreVolume interface {
 	// GetPath return the path of the restore volume's block device file.
 	GetPath() string
 
-	// BlkDiscard issues `blkdiscard <bdev file>`.
-	BlkDiscard() error
+	// ZeroOut fills the block device with zero.
+	ZeroOut() error
 
 	// Apply diff applies diff to the restore volume
 	ApplyDiff(diffFilePath string) error


### PR DESCRIPTION
We planned to use `blkdiscard` to zero out the restore block device. However, we should use `blkdiscard -z` in this case because `discard` without option doesn't guarantee to zero out the target block device.

We also rename BlkDiscard to ZeroOut and implement this function.