### PR TITLE
test: refactor fin repository

### DIFF
--- a/internal/infrastructure/db/fin_test.go
+++ b/internal/infrastructure/db/fin_test.go
@@ -1,8 +1,6 @@
-package sqlite
+package db
 
 import (
-	"database/sql"
-	"fmt"
 	"os"
 	"testing"
 
@@ -12,16 +10,14 @@ import (
 )
 
 const (
-	testDatasource = "test.db"
-	testUID        = "test-uid"
-	testAction     = model.Backup
+	testDBFile = "test.db"
+	testUID    = "test-uid"
+	testAction = model.Backup
 )
 
 func CreateRepoForTest(t *testing.T) model.FinRepository {
-	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_txlock=exclusive", testDatasource))
-	t.Cleanup(func() { _ = db.Close(); _ = os.Remove(testDatasource) })
-	require.NoError(t, err)
-	repo, err := New(db)
+	repo, err := New(testDBFile)
+	t.Cleanup(func() { _ = repo.Close(); _ = os.Remove(testDBFile) })
 	require.NoError(t, err)
 
 	return repo


### PR DESCRIPTION
- Rename `sqlite3` package to `db` because we don't plan to implement another fin repository than sqlite3-based one in the near future.
- Open sqlite3 database inside `db.New()` with exclusive lock. We can avoid forgetting to specify exclusive lock. As a result of this change, users are now required to close fin repository after using it.