### PR TITLE
change pvc name prefix for fin volume

### DIFF
--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -71,6 +71,5 @@ func enqueueOnJobCompletion(e event.UpdateEvent) bool {
 }
 
 func finVolumePVCName(backup *finv1.FinBackup) string {
-	// FIXME: The naming convention has not been decided yet.
-	return "fin-volume-" + backup.Spec.Node
+	return "fin-" + backup.Spec.Node
 }

--- a/test/e2e/testdata/fin-volume.yaml
+++ b/test/e2e/testdata/fin-volume.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: fin-volume-minikube-worker
+  name: fin-minikube-worker
 spec:
   capacity:
     storage: 200Mi
@@ -17,7 +17,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fin-volume-minikube-worker
+  name: fin-minikube-worker
   namespace: rook-ceph
 spec:
   accessModes:
@@ -26,4 +26,4 @@ spec:
   resources:
     requests:
       storage: 200Mi
-  volumeName: fin-volume-minikube-worker
+  volumeName: fin-minikube-worker


### PR DESCRIPTION
Current pvc name prefix for fin volume is "fin-volume-". Howerver, it's better to remove "volume-" because of its redundancy. PVCs for fin volumes are apparently "volumes" because they are Persistent"Volume"Claim.