### PR TITLE
test: deletion job: use appropriate assertion

### DIFF
--- a/internal/job/deletion/deletion_test.go
+++ b/internal/job/deletion/deletion_test.go
@@ -251,7 +251,7 @@ func TestDelete_RawAndDiffCase_Success(t *testing.T) {
 	assert.Empty(t, updatedMetadata.Diff)
 
 	for i := range partCount {
-		assert.NoFileExistsf(t, nlvRepo.GetDiffPartPath(targetSnapshotID, i), "diff part-%d file should have been deleted", i)
+		assert.NoDirExistsf(t, nlvRepo.GetDiffPartPath(targetSnapshotID, i), "diff part-%d file should have been deleted", i)
 	}
 
 	// Assert
@@ -420,7 +420,7 @@ func TestDelete_Retry_RawAndDiffCase_Success(t *testing.T) {
 	assert.Empty(t, updatedMetadata.Diff)
 
 	for i := range partCount {
-		assert.NoFileExistsf(t, nlvRepo.GetDiffPartPath(targetSnapshotID, i), "diff part-%d file should have been deleted", i)
+		assert.NoDirExistsf(t, nlvRepo.GetDiffPartPath(targetSnapshotID, i), "diff part-%d file should have been deleted", i)
 	}
 
 	// Assert


### PR DESCRIPTION
We should use *DirExists rather than *FileExists on checking the existence of directories.