### PR TITLE
changed data size variables type to uint64

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -103,7 +103,7 @@ func backupJobMain() error {
 	if maxPartSizeStr == "" {
 		return fmt.Errorf("MAX_PART_SIZE environment variable is not set")
 	}
-	maxPartSize, err := strconv.Atoi(maxPartSizeStr)
+	maxPartSize, err := strconv.ParseUint(maxPartSizeStr, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid MAX_PART_SIZE: %w", err)
 	}

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -43,7 +43,7 @@ func controllerMain(args []string) {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	var rawImgExpansionUnitSize int
+	var rawImgExpansionUnitSize uint64
 
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -55,7 +55,7 @@ func controllerMain(args []string) {
 		"If set the metrics endpoint is served securely")
 	fs.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	fs.IntVar(&rawImgExpansionUnitSize, "raw-img-expansion-unit-size", 0,
+	fs.Uint64Var(&rawImgExpansionUnitSize, "raw-img-expansion-unit-size", 0,
 		"Set FIN_RAW_IMG_EXPANSION_UNIT_SIZE in backup job.")
 	opts := zap.Options{
 		Development: true,

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -62,7 +62,7 @@ func restoreJobMain() error {
 	if rawImageChunkSizeStr == "" {
 		return fmt.Errorf("RAW_IMAGE_CHUNK_SIZE environment variable is not set")
 	}
-	rawImageChunkSize, err := strconv.ParseInt(rawImageChunkSizeStr, 10, 64)
+	rawImageChunkSize, err := strconv.ParseUint(rawImageChunkSizeStr, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid RAW_IMAGE_CHUNK_SIZE: %w", err)
 	}

--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -63,7 +63,7 @@ type FinBackupReconciler struct {
 	podImage                string
 	maxPartSize             *resource.Quantity
 	snapRepo                model.RBDSnapshotRepository
-	rawImgExpansionUnitSize int
+	rawImgExpansionUnitSize uint64
 }
 
 func NewFinBackupReconciler(
@@ -73,7 +73,7 @@ func NewFinBackupReconciler(
 	podImage string,
 	maxPartSize *resource.Quantity,
 	snapRepo model.RBDSnapshotRepository,
-	rawImgExpansionUnitSize int,
+	rawImgExpansionUnitSize uint64,
 ) *FinBackupReconciler {
 	return &FinBackupReconciler{
 		Client:                  client,
@@ -632,7 +632,7 @@ func (r *FinBackupReconciler) createOrUpdateBackupJob(
 		if r.rawImgExpansionUnitSize != 0 {
 			job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  "FIN_RAW_IMG_EXPANSION_UNIT_SIZE",
-				Value: strconv.Itoa(r.rawImgExpansionUnitSize),
+				Value: strconv.FormatUint(r.rawImgExpansionUnitSize, 10),
 			})
 		}
 

--- a/internal/diffgenerator/diffgenerator.go
+++ b/internal/diffgenerator/diffgenerator.go
@@ -160,7 +160,7 @@ func makeUpdatedDataChunkReader(offset, length uint64, data []byte) (io.Reader, 
 		)
 		return io.MultiReader(&buf, chacha8), nil
 	}
-	if len(data) != int(length) {
+	if uint64(len(data)) != length {
 		return nil, errors.New("data length does not match specified length")
 	}
 	buf.Write(data)

--- a/internal/infrastructure/ceph/rbd_test.go
+++ b/internal/infrastructure/ceph/rbd_test.go
@@ -75,9 +75,9 @@ func TestZeroFill_success(t *testing.T) {
 	// - 0 ~ firstBlockLength: 0xff
 	// - firstBlockLength ~ secondBlockLength: 0x00 (By Zerofill())
 	// - secondBlockLength ~ fileSize: 0xff
-	fileSize := 10 * 1024
-	firstBlockLength := 1*1024 + 1
-	secondBlockLength := 2*1024 + 1
+	fileSize := uint64(10 * 1024)
+	firstBlockLength := uint64(1*1024 + 1)
+	secondBlockLength := uint64(2*1024 + 1)
 
 	buf := make([]byte, fileSize)
 	for i := range buf {
@@ -86,7 +86,7 @@ func TestZeroFill_success(t *testing.T) {
 	_, err = f.Write(buf)
 	require.NoError(t, err)
 
-	err = zeroFill(f, int64(firstBlockLength), int64(secondBlockLength))
+	err = zeroFill(f, firstBlockLength, secondBlockLength)
 	assert.NoError(t, err)
 
 	_, err = f.Seek(0, io.SeekStart)
@@ -537,10 +537,10 @@ func openFile(t *testing.T, path string) *os.File {
 
 type resizedReader struct {
 	r io.Reader
-	n int64
+	n uint64
 }
 
-func newResizedReader(r io.Reader, size int64) *resizedReader {
+func newResizedReader(r io.Reader, size uint64) *resizedReader {
 	return &resizedReader{r: r, n: size}
 }
 
@@ -548,7 +548,7 @@ func (rr *resizedReader) Read(p []byte) (int, error) {
 	if rr.n <= 0 {
 		return 0, io.EOF
 	}
-	if int64(len(p)) > rr.n {
+	if uint64(len(p)) > rr.n {
 		p = p[0:rr.n]
 	}
 
@@ -560,7 +560,7 @@ func (rr *resizedReader) Read(p []byte) (int, error) {
 		err = nil
 		n = len(p)
 	}
-	rr.n -= int64(n)
+	rr.n -= uint64(n)
 	return n, err
 }
 
@@ -571,7 +571,7 @@ func TestResizedReader(t *testing.T) {
 	assert.Equal(t, []byte("aaaaa\x00\x00\x00\x00\x00"), got)
 }
 
-func openFileResized(t *testing.T, path string, size int64) io.Reader {
+func openFileResized(t *testing.T, path string, size uint64) io.Reader {
 	t.Helper()
 
 	file, err := os.Open(path)

--- a/internal/infrastructure/fake/rbd.go
+++ b/internal/infrastructure/fake/rbd.go
@@ -21,14 +21,14 @@ type RawImage struct {
 
 type ExportedDiff struct {
 	PoolName      string    `json:"poolName"`
-	ReadOffset    int       `json:"readOffset"`
-	ReadLength    int       `json:"readLength"`
+	ReadOffset    uint64    `json:"readOffset"`
+	ReadLength    uint64    `json:"readLength"`
 	FromSnap      *string   `json:"fromSnap"`
 	MidSnapPrefix string    `json:"midSnapPrefix"`
 	ImageName     string    `json:"imageName"`
 	SnapID        int       `json:"snapId"`
 	SnapName      string    `json:"snapName"`
-	SnapSize      int       `json:"snapSize"`
+	SnapSize      uint64    `json:"snapSize"`
 	SnapTimestamp time.Time `json:"snapTimestamp"`
 }
 
@@ -66,7 +66,7 @@ func NewRBDRepository(
 
 // CreateFakeSnapshot creates a fake snapshot for the specified pool and image.
 // It returns the snapshot ID of the created one.
-func (r *RBDRepository) CreateFakeSnapshot(name string, size int, timestamp time.Time) *model.RBDSnapshot {
+func (r *RBDRepository) CreateFakeSnapshot(name string, size uint64, timestamp time.Time) *model.RBDSnapshot {
 	r.lastSnapID++
 	snapshot := &model.RBDSnapshot{
 		ID:        r.lastSnapID,

--- a/internal/infrastructure/fake/restore.go
+++ b/internal/infrastructure/fake/restore.go
@@ -47,6 +47,6 @@ func (r *restoreVolume) AppliedDiffs() []*ExportedDiff {
 	return r.appliedDiffs
 }
 
-func (r *restoreVolume) CopyChunk(rawPath string, index int, chunkSize int64) error {
+func (r *restoreVolume) CopyChunk(rawPath string, index int, chunkSize uint64) error {
 	return r.real.CopyChunk(rawPath, index, chunkSize)
 }

--- a/internal/infrastructure/restore/restore.go
+++ b/internal/infrastructure/restore/restore.go
@@ -49,7 +49,7 @@ func (r *RestoreVolume) ApplyDiff(diffPath string) error {
 	return errors.New("not implemented")
 }
 
-func (r *RestoreVolume) CopyChunk(rawPath string, index int, chunkSize int64) error {
+func (r *RestoreVolume) CopyChunk(rawPath string, index int, chunkSize uint64) error {
 	rawFile, err := os.Open(rawPath)
 	if err != nil {
 		return fmt.Errorf("failed to open `%s`: %w", rawPath, err)
@@ -62,13 +62,13 @@ func (r *RestoreVolume) CopyChunk(rawPath string, index int, chunkSize int64) er
 	}
 	defer func() { _ = resVol.Close() }()
 
-	if _, err := rawFile.Seek(int64(index)*chunkSize, io.SeekStart); err != nil {
+	if _, err := rawFile.Seek(int64(index)*int64(chunkSize), io.SeekStart); err != nil {
 		return fmt.Errorf("failed to seek `%s` to %d: %w",
-			rawPath, int64(index)*chunkSize, err)
+			rawPath, int64(index)*int64(chunkSize), err)
 	}
-	if _, err = resVol.Seek(int64(index)*chunkSize, io.SeekStart); err != nil {
+	if _, err = resVol.Seek(int64(index)*int64(chunkSize), io.SeekStart); err != nil {
 		return fmt.Errorf("failed to seek `%s` to %d: %w",
-			r.GetPath(), int64(index)*chunkSize, err)
+			r.GetPath(), int64(index)*int64(chunkSize), err)
 	}
 
 	buf := make([]byte, chunkSize)

--- a/internal/job/backup/backup.go
+++ b/internal/job/backup/backup.go
@@ -32,7 +32,7 @@ type Backup struct {
 	targetPVCName             string
 	targetPVCNamespace        string
 	targetPVCUID              string
-	maxPartSize               int
+	maxPartSize               uint64
 }
 
 func NewBackup(in *input.Backup) *Backup {
@@ -244,7 +244,7 @@ func (b *Backup) loopExportDiff(
 	for i := privateData.NextStorePart; i < partCount; i++ {
 		if err := b.rbdRepo.ExportDiff(&model.ExportDiffInput{
 			PoolName:       b.targetRBDPool,
-			ReadOffset:     b.maxPartSize * i,
+			ReadOffset:     b.maxPartSize * uint64(i),
 			ReadLength:     b.maxPartSize,
 			FromSnap:       sourceSnapshotName,
 			MidSnapPrefix:  targetSnapshot.Name,
@@ -292,11 +292,11 @@ func (b *Backup) loopApplyDiff(privateData *backupPrivateData, targetSnapshot *m
 	for i := privateData.NextPatchPart; i < partCount; i++ {
 		sourceSnapshotName := ""
 		if i != 0 {
-			sourceSnapshotName = fmt.Sprintf("%s-offset-%d", targetSnapshot.Name, i*b.maxPartSize)
+			sourceSnapshotName = fmt.Sprintf("%s-offset-%d", targetSnapshot.Name, uint64(i)*b.maxPartSize)
 		}
 		targetSnapshotName := targetSnapshot.Name
 		if i != partCount-1 {
-			targetSnapshotName = fmt.Sprintf("%s-offset-%d", targetSnapshot.Name, (i+1)*b.maxPartSize)
+			targetSnapshotName = fmt.Sprintf("%s-offset-%d", targetSnapshot.Name, uint64(i+1)*b.maxPartSize)
 		}
 		if err := b.rbdRepo.ApplyDiffToRawImage(
 			b.nodeLocalVolumeRepo.GetRawImagePath(),

--- a/internal/job/backup/backup_test.go
+++ b/internal/job/backup/backup_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 type setupInput struct {
-	fullSnapshotSize, incrementalSnapshotSize int
-	maxPartSize                               int
+	fullSnapshotSize, incrementalSnapshotSize uint64
+	maxPartSize                               uint64
 }
 
 type setupOutput struct {
@@ -38,12 +38,12 @@ type setupOutput struct {
 }
 
 func setup(t *testing.T, input *setupInput) *setupOutput {
-	maxPartSize := 512
+	maxPartSize := uint64(512)
 	if input.maxPartSize != 0 {
 		maxPartSize = input.maxPartSize
 	}
 
-	fullSnapshotSize := 900
+	fullSnapshotSize := uint64(900)
 	if input.fullSnapshotSize != 0 {
 		fullSnapshotSize = input.fullSnapshotSize
 	}
@@ -62,7 +62,7 @@ func setup(t *testing.T, input *setupInput) *setupOutput {
 	fullBackupInput.NodeLocalVolumeRepo = nlvRepo
 
 	// Take a fake snapshot for incremental backup
-	incrementalSnapshotSize := 1000
+	incrementalSnapshotSize := uint64(1000)
 	incrementalSnapshot := rbdRepo.CreateFakeSnapshot(utils.GetUniqueName("snap-"), incrementalSnapshotSize, time.Now())
 
 	// Create an incremental backup input
@@ -113,7 +113,7 @@ func TestFullBackup_Success(t *testing.T) {
 	rawImage, err := fake.ReadRawImage(cfg.nlvRepo.GetRawImagePath())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(rawImage.AppliedDiffs))
-	assert.Equal(t, 0, rawImage.AppliedDiffs[0].ReadOffset)
+	assert.Equal(t, uint64(0), rawImage.AppliedDiffs[0].ReadOffset)
 	assert.Equal(t, cfg.fullBackupInput.MaxPartSize, rawImage.AppliedDiffs[0].ReadLength)
 	assert.Equal(t, cfg.fullBackupInput.MaxPartSize, rawImage.AppliedDiffs[1].ReadOffset)
 	assert.Equal(t, cfg.fullBackupInput.MaxPartSize, rawImage.AppliedDiffs[1].ReadLength)
@@ -296,7 +296,7 @@ func Test_FullBackup_Success_Resume(t *testing.T) {
 			fmt.Sprintf("nextStorePart=%d nextPatchPart=%d", tc.nextStorePart, tc.nextPatchPart),
 			func(t *testing.T) {
 				// Arrange
-				snapshotSize, maxPartSize := 1000, 400 // max part size will be 3 (= ceil(1000/400))
+				snapshotSize, maxPartSize := uint64(1000), uint64(400) // max part size will be 3 (= ceil(1000/400))
 				cfg := setup(t, &setupInput{
 					fullSnapshotSize:        snapshotSize,
 					incrementalSnapshotSize: snapshotSize,
@@ -309,7 +309,7 @@ func Test_FullBackup_Success_Resume(t *testing.T) {
 				for i := 0; i < tc.nextStorePart; i++ {
 					err := cfg.rbdRepo.ExportDiff(&model.ExportDiffInput{
 						PoolName:       cfg.fullBackupInput.TargetRBDPoolName,
-						ReadOffset:     cfg.fullBackupInput.MaxPartSize * i,
+						ReadOffset:     cfg.fullBackupInput.MaxPartSize * uint64(i),
 						ReadLength:     cfg.fullBackupInput.MaxPartSize,
 						FromSnap:       nil,
 						MidSnapPrefix:  cfg.fullSnapshot.Name,
@@ -354,7 +354,7 @@ func Test_FullBackup_Success_Resume(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.Equal(t, 3-tc.nextPatchPart, len(rawImage.AppliedDiffs))
-				off := tc.nextPatchPart * maxPartSize
+				off := uint64(tc.nextPatchPart) * maxPartSize
 				for _, diff := range rawImage.AppliedDiffs {
 					assert.Equal(t, cfg.fullBackupInput.TargetRBDPoolName, diff.PoolName)
 					assert.Nil(t, diff.FromSnap)
@@ -405,7 +405,7 @@ func Test_IncrementalBackup_Success_Resume(t *testing.T) {
 
 	// Arrange
 	nextStorePart := 1
-	snapshotSize, maxPartSize := 1000, 400 // max part size will be 3 (= ceil(1000/400))
+	snapshotSize, maxPartSize := uint64(1000), uint64(400) // max part size will be 3 (= ceil(1000/400))
 
 	cfg := setup(t, &setupInput{
 		fullSnapshotSize:        snapshotSize,
@@ -532,7 +532,7 @@ func Test_FullBackup_Success_DifferentNode(t *testing.T) {
 		assert.Equal(t, cfg.incrementalSnapshot.Size, diff.SnapSize)
 		assert.True(t, cfg.incrementalSnapshot.Timestamp.Equal(diff.SnapTimestamp))
 
-		assert.Equal(t, i*cfg.incrementalBackupInput.MaxPartSize, diff.ReadOffset)
+		assert.Equal(t, uint64(i)*cfg.incrementalBackupInput.MaxPartSize, diff.ReadOffset)
 		assert.Equal(t, cfg.incrementalBackupInput.MaxPartSize, diff.ReadLength)
 	}
 

--- a/internal/job/deletion/deletion.go
+++ b/internal/job/deletion/deletion.go
@@ -123,11 +123,11 @@ func (d *Deletion) applyAllDiffParts(raw, diff *job.BackupMetadataEntry) error {
 	for i := privateData.NextPatchPart; i < partCount; i++ {
 		sourceSnapshotName := raw.SnapName
 		if i != 0 {
-			sourceSnapshotName = fmt.Sprintf("%s-offset-%d", diff.SnapName, i*diff.PartSize)
+			sourceSnapshotName = fmt.Sprintf("%s-offset-%d", diff.SnapName, uint64(i)*diff.PartSize)
 		}
 		targetSnapshotName := diff.SnapName
 		if i != partCount-1 {
-			targetSnapshotName = fmt.Sprintf("%s-offset-%d", diff.SnapName, (i+1)*diff.PartSize)
+			targetSnapshotName = fmt.Sprintf("%s-offset-%d", diff.SnapName, uint64(i+1)*diff.PartSize)
 		}
 		diffPartPath := d.nodeLocalVolumeRepo.GetDiffPartPath(diff.SnapID, i)
 		if err := d.rbdRepo.ApplyDiffToRawImage(

--- a/internal/job/deletion/deletion_test.go
+++ b/internal/job/deletion/deletion_test.go
@@ -153,15 +153,15 @@ func TestDelete_RawAndDiffCase_Success(t *testing.T) {
 	actionUID := uuid.New().String()
 	targetRBDPoolName := "test-pool"
 	targetRBDImageName := "test-image"
-	partSize := 512
+	partSize := uint64(512)
 
 	previousSnapshotID := 1
 	previousSnapshotName := "test-snap1"
-	previousSnapshotSize := 1024
+	previousSnapshotSize := uint64(1024)
 
 	targetSnapshotID := 2
 	targetSnapshotName := "test-snap2"
-	targetSnapshotSize := 2048
+	targetSnapshotSize := uint64(2048)
 	targetPVCUID := uuid.New().String()
 
 	targetSnapshotTimestamp := time.Now().Round(0)
@@ -218,7 +218,7 @@ func TestDelete_RawAndDiffCase_Success(t *testing.T) {
 	for i := range partCount {
 		err := rbdRepo.ExportDiff(&model.ExportDiffInput{
 			PoolName:       targetRBDPoolName,
-			ReadOffset:     i * partSize,
+			ReadOffset:     uint64(i) * partSize,
 			ReadLength:     partSize,
 			FromSnap:       &previousSnapshotName,
 			MidSnapPrefix:  "test-prefix",
@@ -294,15 +294,15 @@ func TestDelete_Retry_RawAndDiffCase_Success(t *testing.T) {
 	actionUID := uuid.New().String()
 	targetRBDPoolName := "test-pool"
 	targetRBDImageName := "test-image"
-	partSize := 512
+	partSize := uint64(512)
 
 	previousSnapshotID := 1
 	previousSnapshotName := "test-snap1"
-	previousSnapshotSize := 1024
+	previousSnapshotSize := uint64(1024)
 
 	targetSnapshotID := 2
 	targetSnapshotName := "test-snap2"
-	targetSnapshotSize := 2048
+	targetSnapshotSize := uint64(2048)
 	targetPVCUID := uuid.New().String()
 
 	targetSnapshotTimestamp := time.Now().Round(0)
@@ -380,7 +380,7 @@ func TestDelete_Retry_RawAndDiffCase_Success(t *testing.T) {
 	for i := range partCount {
 		err := rbdRepo.ExportDiff(&model.ExportDiffInput{
 			PoolName:       targetRBDPoolName,
-			ReadOffset:     i * partSize,
+			ReadOffset:     uint64(i) * partSize,
 			ReadLength:     partSize,
 			FromSnap:       &previousSnapshotName,
 			MidSnapPrefix:  "test-prefix",

--- a/internal/job/input/backup.go
+++ b/internal/job/input/backup.go
@@ -20,5 +20,5 @@ type Backup struct {
 	TargetPVCName             string
 	TargetPVCNamespace        string
 	TargetPVCUID              string
-	MaxPartSize               int
+	MaxPartSize               uint64
 }

--- a/internal/job/input/restore.go
+++ b/internal/job/input/restore.go
@@ -13,6 +13,6 @@ type Restore struct {
 	RetryInterval       time.Duration
 	ActionUID           string
 	TargetSnapshotID    int
-	RawImageChunkSize   int64
+	RawImageChunkSize   uint64
 	TargetPVCUID        string
 }

--- a/internal/job/restore/restore.go
+++ b/internal/job/restore/restore.go
@@ -19,7 +19,7 @@ type Restore struct {
 	retryInterval       time.Duration
 	actionUID           string
 	targetSnapshotID    int
-	rawImageChunkSize   int64
+	rawImageChunkSize   uint64
 	targetPVCUID        string
 }
 
@@ -142,7 +142,7 @@ func (r *Restore) doRestoreRawImagePhase(privateData *restorePrivateData, raw *j
 	return setRestorePrivateData(r.repo, r.actionUID, privateData)
 }
 
-func (r *Restore) loopCopyChunk(privateData *restorePrivateData, rawImageSize int) error {
+func (r *Restore) loopCopyChunk(privateData *restorePrivateData, rawImageSize uint64) error {
 	chunkCount := int(math.Ceil(float64(rawImageSize) / float64(r.rawImageChunkSize)))
 	for i := privateData.NextRawImageChunk; i < chunkCount; i++ {
 		if err := r.restoreVol.CopyChunk(r.nodeLocalVolumeRepo.GetRawImagePath(), i, r.rawImageChunkSize); err != nil {

--- a/internal/job/util.go
+++ b/internal/job/util.go
@@ -25,8 +25,8 @@ type BackupMetadata struct {
 type BackupMetadataEntry struct {
 	SnapID    int       `json:"snapID"`
 	SnapName  string    `json:"snapName"`
-	SnapSize  int       `json:"snapSize"`
-	PartSize  int       `json:"partSize"`
+	SnapSize  uint64    `json:"snapSize"`
+	PartSize  uint64    `json:"partSize"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 

--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -82,14 +82,14 @@ func (t *RBDTimeStamp) UnmarshalJSON(data []byte) error {
 type RBDSnapshot struct {
 	ID        int          `json:"id"`
 	Name      string       `json:"name"`
-	Size      int          `json:"size"`
+	Size      uint64       `json:"size"`
 	Timestamp RBDTimeStamp `json:"timestamp"`
 }
 
 type ExportDiffInput struct {
 	PoolName       string
-	ReadOffset     int
-	ReadLength     int
+	ReadOffset     uint64
+	ReadLength     uint64
 	FromSnap       *string
 	MidSnapPrefix  string
 	ImageName      string

--- a/internal/model/volume.go
+++ b/internal/model/volume.go
@@ -12,5 +12,5 @@ type RestoreVolume interface {
 	ApplyDiff(diffFilePath string) error
 
 	// CopyChunk copy a chunk from raw.img to the restore volume
-	CopyChunk(rawPath string, index int, chunkSize int64) error
+	CopyChunk(rawPath string, index int, chunkSize uint64) error
 }


### PR DESCRIPTION
When representing data sizes in modules, int, uint, and uint64 are mixed. To reduce the cost of casting and avoid unnecessary consideration of negative numbers, we will unify them to uint64.