### PR TITLE
make both FinBackup and FinRestore possible on arbitrary nses

### DIFF
--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -118,10 +118,6 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.reconcileDelete(ctx, &backup)
 	}
 
-	if backup.GetNamespace() != r.cephClusterNamespace {
-		return ctrl.Result{}, nil
-	}
-
 	if backup.IsReady() {
 		return ctrl.Result{}, nil
 	}
@@ -241,7 +237,7 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	var job batchv1.Job
-	err = r.Get(ctx, client.ObjectKey{Namespace: backup.GetNamespace(), Name: backupJobName(&backup)}, &job)
+	err = r.Get(ctx, client.ObjectKey{Namespace: r.cephClusterNamespace, Name: backupJobName(&backup)}, &job)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -280,7 +276,7 @@ func (r *FinBackupReconciler) reconcileDelete(ctx context.Context, backup *finv1
 	backupJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupJobName(backup),
-			Namespace: backup.GetNamespace(),
+			Namespace: r.cephClusterNamespace,
 		},
 	}
 	err := r.Delete(ctx, backupJob)
@@ -302,7 +298,7 @@ func (r *FinBackupReconciler) reconcileDelete(ctx context.Context, backup *finv1
 		}
 
 		var cleanupJob batchv1.Job
-		err = r.Get(ctx, client.ObjectKey{Namespace: backup.GetNamespace(), Name: cleanupJobName(backup)}, &cleanupJob)
+		err = r.Get(ctx, client.ObjectKey{Namespace: r.cephClusterNamespace, Name: cleanupJobName(backup)}, &cleanupJob)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get cleanup job: %w", err)
 		}
@@ -321,7 +317,7 @@ func (r *FinBackupReconciler) reconcileDelete(ctx context.Context, backup *finv1
 		}
 
 		var deletionJob batchv1.Job
-		err = r.Get(ctx, client.ObjectKey{Namespace: backup.GetNamespace(), Name: deletionJobName(backup)}, &deletionJob)
+		err = r.Get(ctx, client.ObjectKey{Namespace: r.cephClusterNamespace, Name: deletionJobName(backup)}, &deletionJob)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get deletion job: %w", err)
 		}

--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -1,72 +1,9 @@
 package controller
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	finv1 "github.com/cybozu-go/fin/api/v1"
 )
 
 var _ = Describe("FinBackup Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default",
-		}
-		finbackup := &finv1.FinBackup{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind FinBackup")
-			err := k8sClient.Get(ctx, typeNamespacedName, finbackup)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &finv1.FinBackup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: finv1.FinBackupSpec{
-						PVC:          "test-pvc",
-						PVCNamespace: "test-ns",
-						Node:         "test-node",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &finv1.FinBackup{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance FinBackup")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &FinBackupReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
-		})
-	})
+	// TODO(user): Add unit tests of controller's reconciliation logic.
 })

--- a/internal/controller/finrestore_controller.go
+++ b/internal/controller/finrestore_controller.go
@@ -114,12 +114,6 @@ func (r *FinRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	if restore.GetNamespace() != r.cephClusterNamespace {
-		logger.Info("restore is not managed by the target Ceph cluster",
-			"restore", restore.Name, "namespace", restore.Namespace, "clusterNamespace", r.cephClusterNamespace)
-		return ctrl.Result{}, nil
-	}
-
 	if restore.DeletionTimestamp.IsZero() {
 		return r.reconcileCreateOrUpdate(ctx, &restore)
 	} else {

--- a/internal/controller/finrestore_controller_test.go
+++ b/internal/controller/finrestore_controller_test.go
@@ -1,68 +1,9 @@
 package controller
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	finv1 "github.com/cybozu-go/fin/api/v1"
 )
 
 var _ = Describe("FinRestore Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		finrestore := &finv1.FinRestore{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind FinRestore")
-			err := k8sClient.Get(ctx, typeNamespacedName, finrestore)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &finv1.FinRestore{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &finv1.FinRestore{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance FinRestore")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &FinRestoreReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
-		})
-	})
+	// TODO(user): Add unit tests of controller's reconciliation logic.
 })


### PR DESCRIPTION
Both FinBackup and FinRestore can belong to arbitrary namespaces. Howerver, these resources are forced to exist on the same namespace as rook/ceph cluster. Let's fix it.
    
As a side effect of this change, I found that the unit tests for both resources' controllers, that were automaticall generated by kubebuilder, has always succeeded due to the above mentioned namespace restriction. In other words, these tests were virtually noop.
    
Let's remove these tests because the purpose of these tests are just to verify running reconcilers without error and this scenarios are covered by the existing e2e tests.