### PR TITLE
support FinRestore deletion

### DIFF
--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -36,14 +36,14 @@ func restoreTestSuite() {
 			"--for=jsonpath={.status.phase}=Bound", "--timeout=2m")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
 
-		By("creating a pod")
+		By("creating a pod to write data to the PVC")
 		_, stderr, err = kubectl("apply", "-f", "testdata/test-pod.yaml")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
 		_, stderr, err = kubectl("wait", "pod", "-n", pvcNamespace, "test-pod",
 			"--for=condition=Ready", "--timeout=2m")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
 
-		By("writing data to the pvc")
+		By("writing data to the PVC")
 		_, stderr, err = kubectl("exec", "-n", pvcNamespace, "test-pod", "--",
 			"dd", "if=/dev/urandom", "of=/data", "bs=1K", "count=1")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
@@ -69,22 +69,85 @@ func restoreTestSuite() {
 		_, stderr, err = kubectl("wait", "finrestore", "-n", rookNamespace, "finrestore-test",
 			"--for=condition=ReadyToUse", "--timeout=2m")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
 		By("verifying the existence of the restore PVC")
 		_, stderr, err = kubectl("wait", "pvc", "-n", rookNamespace, "finrestore-test",
 			"--for=jsonpath={.status.phase}=Bound", "--timeout=2m")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
-		By("verifying the data in the restore PVC")
-		actualWrittenData, stderr, err := execWrapper(minikube, nil, "ssh", "--native-ssh=false", "--",
-			"dd", fmt.Sprintf("if=/fin/%s/%s/raw.img", pvcNamespace, pvcName), "bs=1K", "count=1", "status=none")
+
+		By("creating a pod to verify the contents in the restore PVC")
+		_, stderr, err = kubectl("apply", "-f", "testdata/test-restore-pod.yaml")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
-		Expect(actualWrittenData).To(Equal(expectedWrittenData), "Data in restore PVC does not match the expected data")
+		_, stderr, err = kubectl("wait", "pod", "-n", rookNamespace, "test-restore-pod",
+			"--for=condition=Ready", "--timeout=2m")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
+		By("verifying the data in the restore PVC")
+		restoredData, stderr, err := kubectl("exec", "-n", rookNamespace, "test-restore-pod", "--",
+			"dd", "if=/restore", "bs=1K", "count=1")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+		Expect(restoredData).To(Equal(expectedWrittenData), "Data in restore PVC does not match the expected data")
+	})
+
+	// CSATEST-1552
+	// Description:
+	//   Delete a FinRestore with no error.
+	//
+	// Arrange:
+	//   - An RBD PVC exists.
+	//   - The FinBackup referring the above PVC is ready to use.
+	//   - The FinRestore referring the above FinBackup is ready to use.
+	// Act:
+	//   Delete FinRestore.
+	// Assert:
+	//   - FinRestore doesn't exists.
+	//   - Restore PVC exists.
+	//   - Restore job PVC doesn't exist.
+	//   - Restore job PV doesn't exist.
+	It("should delete restore", func() {
+		// Arrange
+		By("getting FinRestore's UID")
+		finrestoreUID, stderr, err := kubectl("get", "finrestore", "-n", rookNamespace,
+			"finrestore-test", "-ojsonpath={.metadata.uid}")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
+		// Action
+		By("deleting FinRestore")
+		_, stderr, err = kubectl("delete", "-f", "testdata/finrestore.yaml")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
+		// Assert
+		_, stderr, err = kubectl("wait", "finrestore", "-n", rookNamespace,
+			"finrestore-test", "--for=delete", "--timeout=3m")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
+		By("verifying the deletion of the restore job")
+		_, stderr, err = kubectl("wait", "job", "-n", rookNamespace,
+			fmt.Sprintf("fin-restore-%s", finrestoreUID), "--for=delete", "--timeout=3m")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
+		By("verifying the deletion of the restore job PVC")
+		_, stderr, err = kubectl("wait", "pvc", "-n", rookNamespace,
+			fmt.Sprintf("fin-restore-%s", finrestoreUID), "--for=delete", "--timeout=3m")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+
+		By("verifying the deletion of the restore job PV")
+		_, stderr, err = kubectl("wait", "pvc",
+			fmt.Sprintf("fin-restore-%s", finrestoreUID), "--for=delete", "--timeout=3m")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
 	})
 
 	AfterAll(func() {
-		By("deleting the backup")
-		_, stderr, err := kubectl("delete", "-f", "testdata/finbackup.yaml")
+		By("deleting the pod to verify the contents in the restore PVC")
+		_, stderr, err := kubectl("delete", "-f", "testdata/test-restore-pod.yaml")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
-		By("deleting the pod")
+		By("deleting the restore PVC")
+		_, stderr, err = kubectl("delete", "-n", "rook-ceph", "pvc", "finrestore-test")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+		By("deleting the backup")
+		_, stderr, err = kubectl("delete", "-f", "testdata/finbackup.yaml")
+		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
+		By("deleting the pod to write data to the PVC")
 		_, stderr, err = kubectl("delete", "-f", "testdata/test-pod.yaml")
 		Expect(err).NotTo(HaveOccurred(), "stderr: "+string(stderr))
 		By("deleting the PVC")

--- a/test/e2e/testdata/test-restore-pod.yaml
+++ b/test/e2e/testdata/test-restore-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-restore-pod
+  namespace: rook-ceph
+spec:
+  volumes:
+    - name: finrestore-test
+      persistentVolumeClaim:
+        claimName: finrestore-test
+  containers:
+    - name: test-restore-pod
+      image: ghcr.io/cybozu/ubuntu:24.04
+      command: ["pause"]
+      volumeDevices:
+        - devicePath: "/restore"
+          name: finrestore-test


### PR DESCRIPTION
- Fix wrong verification of the contents of the restore PVC.
- Implement FinRestore deletion logic.

NOTE: We should set the appropriate delete propagation policy on Job deletion to delete the corresponding pod. It's because the default policy is `Orphan`.