### PR TITLE
removeSnapshot falls back to PVC->PV for RBD pool/image when annotations are missing

### DIFF
--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -54,7 +53,6 @@ const (
 )
 
 var (
-	errSnapshotNotFound     = errors.New("snapshot not found")
 	cleanupJobRequeueAfter  = 5 * time.Second
 	deletionJobRequeueAfter = 1 * time.Minute
 )
@@ -280,20 +278,10 @@ func (r *FinBackupReconciler) createSnapshot(ctx context.Context, backup *finv1.
 	labels[labelBackupTargetPVCUID] = string(pvc.GetUID())
 	backup.SetLabels(labels)
 
-	var pv corev1.PersistentVolume
-	err = r.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, &pv)
+	rbdPool, rbdImage, err := r.getRBDPoolAndImage(ctx, &pvc)
 	if err != nil {
-		logger.Error(err, "failed to get backup target PV")
+		logger.Error(err, "failed to get pool/image from PVC")
 		return ctrl.Result{}, err
-	}
-
-	rbdImage := pv.Spec.CSI.VolumeAttributes["imageName"]
-	if rbdImage == "" {
-		return ctrl.Result{}, errors.New("imageName is not specified in PV")
-	}
-	rbdPool := pv.Spec.CSI.VolumeAttributes["pool"]
-	if rbdPool == "" {
-		return ctrl.Result{}, errors.New("pool is not specified in PV")
 	}
 
 	annotations := backup.GetAnnotations()
@@ -414,16 +402,8 @@ func (r *FinBackupReconciler) reconcileDelete(ctx context.Context, backup *finv1
 			return ctrl.Result{}, err
 		}
 	}
-
-	rbdPool := backup.GetAnnotations()[annotationRBDPool]
-	rbdImage := backup.GetAnnotations()[annotationBackupTargetRBDImage]
-	snapshotName := snapshotName(backup)
-	if err := r.removeSnapshot(rbdPool, rbdImage, snapshotName); err != nil {
-		if !errors.Is(err, errSnapshotNotFound) {
-			logger.Error(err, "failed to remove RBD snapshot")
-			return ctrl.Result{}, err
-		}
-		logger.Info("RBD snapshot not found, skipping removal", "pool", rbdPool, "image", rbdImage, "snapName", snapshotName)
+	if err := r.removeSnapshot(ctx, backup); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	controllerutil.RemoveFinalizer(backup, FinBackupFinalizerName)
@@ -435,16 +415,16 @@ func (r *FinBackupReconciler) reconcileDelete(ctx context.Context, backup *finv1
 }
 
 func (r *FinBackupReconciler) createSnapshotIfNeeded(rbdPool, rbdImage, snapName string) (*model.RBDSnapshot, error) {
-	snap, err := r.getSnapshot(rbdPool, rbdImage, snapName)
+	snap, err := findSnapshot(r.snapRepo, rbdPool, rbdImage, snapName)
 	if err != nil {
-		if !errors.Is(err, errSnapshotNotFound) {
+		if !errors.Is(err, model.ErrNotFound) {
 			return nil, fmt.Errorf("failed to get snapshot: %w", err)
 		}
 		err = r.snapRepo.CreateSnapshot(rbdPool, rbdImage, snapName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create snapshot: %w", err)
 		}
-		snap, err = r.getSnapshot(rbdPool, rbdImage, snapName)
+		snap, err = findSnapshot(r.snapRepo, rbdPool, rbdImage, snapName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get snapshot after creation: %w", err)
 		}
@@ -452,9 +432,21 @@ func (r *FinBackupReconciler) createSnapshotIfNeeded(rbdPool, rbdImage, snapName
 	return snap, nil
 }
 
-func (r *FinBackupReconciler) removeSnapshot(rbdPool, rbdImage, snapName string) error {
-	_, err := r.getSnapshot(rbdPool, rbdImage, snapName)
+// removeSnapshot removes the RBD snapshot for the given FinBackup.
+func (r *FinBackupReconciler) removeSnapshot(ctx context.Context, backup *finv1.FinBackup) error {
+	logger := log.FromContext(ctx)
+	rbdPool, rbdImage, err := r.resolveRBDPoolImage(ctx, backup)
 	if err != nil {
+		logger.Error(err, "RBD pool/image not found from FinBackup resource")
+		return nil
+	}
+
+	snapName := snapshotName(backup)
+	if _, err = findSnapshot(r.snapRepo, rbdPool, rbdImage, snapName); err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			logger.Info("RBD snapshot not found", "pool", rbdPool, "image", rbdImage, "snapName", snapName)
+			return nil
+		}
 		return err
 	}
 	err = r.snapRepo.RemoveSnapshot(rbdPool, rbdImage, snapName)
@@ -464,24 +456,43 @@ func (r *FinBackupReconciler) removeSnapshot(rbdPool, rbdImage, snapName string)
 	return nil
 }
 
-func (r *FinBackupReconciler) getSnapshot(rbdPool, rbdImage, snapName string) (*model.RBDSnapshot, error) {
-	snapshots, err := r.snapRepo.ListSnapshots(rbdPool, rbdImage)
-	if err != nil {
-		if errors.Is(err, model.ErrNotFound) {
-			return nil, errSnapshotNotFound
-		}
-		return nil, fmt.Errorf("failed to list snapshots: %w", err)
+func (r *FinBackupReconciler) getRBDPoolAndImage(
+	ctx context.Context,
+	pvc *corev1.PersistentVolumeClaim,
+) (string, string, error) {
+	if pvc == nil {
+		return "", "", errors.New("pvc is nil")
 	}
-	if len(snapshots) == 0 {
-		return nil, fmt.Errorf("%w (snapshot: %s, pool: %s, image: %s)", errSnapshotNotFound, snapName, rbdPool, rbdImage)
+	var pv corev1.PersistentVolume
+	if err := r.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, &pv); err != nil {
+		return "", "", err
 	}
-	i := slices.IndexFunc(snapshots, func(s *model.RBDSnapshot) bool {
-		return s.Name == snapName
-	})
-	if i == -1 {
-		return nil, fmt.Errorf("%w (snapshot: %s, pool: %s, image: %s)", errSnapshotNotFound, snapName, rbdPool, rbdImage)
+	if pv.Spec.CSI == nil || pv.Spec.CSI.VolumeAttributes == nil {
+		return "", "", errors.New("PV.Spec.CSI attributes missing")
 	}
-	return snapshots[i], nil
+	pool := pv.Spec.CSI.VolumeAttributes["pool"]
+	image := pv.Spec.CSI.VolumeAttributes["imageName"]
+	if pool == "" || image == "" {
+		return "", "", fmt.Errorf("pool %q or imageName %q is empty", pool, image)
+	}
+	return pool, image, nil
+}
+
+func (r *FinBackupReconciler) resolveRBDPoolImage(
+	ctx context.Context,
+	backup *finv1.FinBackup,
+) (string, string, error) {
+	rbdPool := backup.GetAnnotations()[annotationRBDPool]
+	rbdImage := backup.GetAnnotations()[annotationBackupTargetRBDImage]
+	if rbdPool != "" && rbdImage != "" {
+		return rbdPool, rbdImage, nil
+	}
+
+	var pvc corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, client.ObjectKey{Namespace: backup.Spec.PVCNamespace, Name: backup.Spec.PVC}, &pvc); err != nil {
+		return "", "", err
+	}
+	return r.getRBDPoolAndImage(ctx, &pvc)
 }
 
 func checkPVCUIDConsistency(backup *finv1.FinBackup, pvc *corev1.PersistentVolumeClaim) error {

--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -119,7 +119,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 	//    - The snapshot for the incremental backup is not deleted
 	Describe("deleting a full backup when both full and incremental backups exist", func() {
 		var finbackup2 *finv1.FinBackup
-		BeforeAll(func(ctx SpecContext) {
+		BeforeEach(func(ctx SpecContext) {
 			By("creating a incremental FinBackup")
 			finbackup2 = NewFinBackup(namespace, "test-backup-2", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup2)).Should(Succeed())
@@ -129,26 +129,26 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			Expect(k8sClient.Delete(ctx, finbackup1)).Should(Succeed())
 		})
 
-		AfterAll(func(ctx SpecContext) {
+		AfterEach(func(ctx SpecContext) {
 			if err := k8sClient.Delete(ctx, finbackup2); err == nil {
 				WaitForFinBackupRemoved(ctx, finbackup2)
 			}
 		})
 
 		It("should delete the FinBackup for the full backup", func(ctx SpecContext) {
+			By("waiting for the FinBackup to be removed")
 			WaitForFinBackupRemoved(ctx, finbackup1)
-		})
-		It("should delete the snapshot for the original FinBackup", func(ctx SpecContext) {
+
+			By("waiting for the snapshot to be removed")
 			Eventually(func(g Gomega) {
 				snapshots, err := rbdRepo.ListSnapshots(rbdPoolName, rbdImageName)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				snapshotIndex := slices.IndexFunc(snapshots, func(snapshot *model.RBDSnapshot) bool {
 					return snapshot.Name == backupJobName(finbackup1)
 				})
-				Expect(snapshotIndex).ShouldNot(Equal(-1))
+				Expect(snapshotIndex).Should(Equal(-1))
 			}, "5s", "1s").Should(Succeed())
-		})
-		It("should keep the FinBackup for the incremental backup", func(ctx SpecContext) {
+			By("checking the FinBackup is not deleted")
 			Consistently(func(g Gomega) {
 				var fb finv1.FinBackup
 				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: finbackup2.Name}, &fb)
@@ -198,7 +198,7 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 		var pv2 *corev1.PersistentVolume
 		var finbackup *finv1.FinBackup
 
-		BeforeAll(func(ctx SpecContext) {
+		BeforeEach(func(ctx SpecContext) {
 			By("creating another storage class for another ceph cluster")
 			otherNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace-2"}}
 			Expect(k8sClient.Create(ctx, otherNamespace)).Should(Succeed())
@@ -215,7 +215,7 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, finbackup)).Should(Succeed())
 		})
 
-		AfterAll(func(ctx SpecContext) {
+		AfterEach(func(ctx SpecContext) {
 			if err := k8sClient.Delete(ctx, finbackup); err == nil {
 				WaitForFinBackupRemoved(ctx, finbackup)
 			}
@@ -223,17 +223,18 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 		})
 
 		It("should not return an error in the reconcile process", func(ctx SpecContext) {
+			By("reconciling the FinBackup")
 			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finbackup)})
 			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("should not create a backup job", func(ctx SpecContext) {
+
+			By("checking if the backup job is not created")
 			jobKey := types.NamespacedName{Name: backupJobName(finbackup), Namespace: namespace}
 			var job batchv1.Job
-			err := k8sClient.Get(ctx, jobKey, &job)
+			err = k8sClient.Get(ctx, jobKey, &job)
 			Expect(err).Should(HaveOccurred())
 			Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
-		})
-		It("should not mark FinBackup as ready when the PVC is in the different Ceph cluster", func(ctx SpecContext) {
+
+			By("checking if the FinBackup is not marked as ready when the PVC is in a different Ceph cluster")
 			Consistently(func(g Gomega) {
 				var fb finv1.FinBackup
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), &fb)

--- a/internal/infrastructure/ceph/rbd.go
+++ b/internal/infrastructure/ceph/rbd.go
@@ -58,6 +58,10 @@ func (r *RBDRepository) ListSnapshots(poolName, imageName string) ([]*model.RBDS
 		return nil, fmt.Errorf("failed to unmarshal RBD snapshots: %w", err)
 	}
 
+	if len(snapshots) == 0 {
+		return nil, fmt.Errorf("no snapshots found for %s: %w", fmt.Sprintf("%s/%s", poolName, imageName), model.ErrNotFound)
+	}
+
 	return snapshots, nil
 }
 


### PR DESCRIPTION
- add getRBDPoolAndImage() and resolveRBDPoolImage()
- centralize snapshot lookup as util.findSnapshot(); return model.ErrNotFound

and

- Aggregate It nodes
    -  BeforeEach and AfterEach are executed for every It node