### PR TITLE
test: ensure no jobs are created when deleting a FinBackup without SnapID

### DIFF
--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -292,72 +292,103 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 		})
 	})
 
-	// CSATEST-1626
+	// CSATEST-1628
 	// Description:
-	//  Do not create any cleanup or deletion jobs when a FinBackup without SnapID is deleted
+	//  Do not create backup job when a FinBackup with a SnapID is created.
 	//
 	// Arrange:
-	//   - Create a PVC and PV.
-	//   - Create a FinBackup resource and set a deletion timestamp.
+	//   - Create a pair of PVC and PV
+	//   - Create a FinBackup with a SnapID.
 	//
 	// Act:
 	//   - Run FinBackup Controller's Reconcile().
 	//
 	// Assert:
 	//   - Reconcile() does not return an error.
-	//   - No cleanup or deletion jobs are created.
-	Context("when reconciling a deleted FinBackup without SnapID", func() {
+	//   - No backup job is created.
+	Context("when reconciling a deleted FinBackup without SnapID", Ordered, func() {
 		var pvc *corev1.PersistentVolumeClaim
 		var pv *corev1.PersistentVolume
 		var finbackup *finv1.FinBackup
-		BeforeEach(func(ctx SpecContext) {
-			By("creating a FinBackup with a pair of PVC and PV")
+		BeforeAll(func(ctx SpecContext) {
+			By("creating a pair of PVC and PV")
 			pvc, pv = NewPVCAndPV(sc, namespace, "test-pvc-snapid", "test-pv-snapid", rbdImageName)
 			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
+
+			By("creating a FinBackup with a SnapID")
 			finbackup = NewFinBackup(namespace, "test-finbackup-snapid", pvc.Name, pvc.Namespace, "test-node")
 			finbackup.Status.SnapID = ptr.To(1)
 			Expect(k8sClient.Create(ctx, finbackup)).Should(Succeed())
-
-			By("reconciling the FinBackup")
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finbackup)})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			By("removing SnapID from the FinBackup")
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), finbackup)).Should(Succeed())
-			finbackup.Status.SnapID = nil
-			Expect(k8sClient.Status().Update(ctx, finbackup)).Should(Succeed())
-
-			By("adding a deletion timestamp")
-			Expect(k8sClient.Delete(ctx, finbackup)).Should(Succeed())
 		})
-
-		AfterEach(func(ctx SpecContext) {
+		AfterAll(func(ctx SpecContext) {
 			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
 		})
 
 		It("should not create any cleanup or deletion jobs", func(ctx SpecContext) {
-			By("reconciling the FinBackup after removing SnapID and adding the deletion timestamp")
+			By("reconciling the FinBackup")
 			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finbackup)})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			By("checking that the FinBackup is deleted")
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), finbackup)
+			By("checking that no backup job is created")
+			backupJobKey := types.NamespacedName{Name: backupJobName(finbackup), Namespace: namespace}
+			var backupJob batchv1.Job
+			err = k8sClient.Get(ctx, backupJobKey, &backupJob)
 			Expect(err).Should(HaveOccurred())
 			Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
+		})
 
-			By("checking that no cleanup or deletion jobs are created")
-			cleanupJobKey := types.NamespacedName{Name: cleanupJobName(finbackup), Namespace: namespace}
-			var cleanupJob batchv1.Job
-			err = k8sClient.Get(ctx, cleanupJobKey, &cleanupJob)
-			Expect(err).Should(HaveOccurred())
-			Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
+		// CSATEST-1626
+		// Description:
+		//  Do not create any cleanup or deletion jobs when a FinBackup without SnapID is deleted
+		//
+		// Arrange:
+		//   - Create a PVC and PV.
+		//   - Create a FinBackup resource and set a deletion timestamp.
+		//   - Remove the SnapID from the FinBackup.
+		//
+		// Act:
+		//   - Run FinBackup Controller's Reconcile().
+		//
+		// Assert:
+		//   - Reconcile() does not return an error.
+		//   - No cleanup or deletion jobs are created.
+		When("the FinBackup is deleted without SnapID", func() {
+			BeforeAll(func(ctx SpecContext) {
+				// This FinBackup has a SnapID in the BeforeAll of the parent Context.
+				// To simulate the condition where a FinBackup without SnapID is deleted,
+				// we remove the SnapID here and add a deletion timestamp.
+				By("removing SnapID from the FinBackup")
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), finbackup)).Should(Succeed())
+				finbackup.Status.SnapID = nil
+				Expect(k8sClient.Status().Update(ctx, finbackup)).Should(Succeed())
+				By("adding a deletion timestamp")
+				Expect(k8sClient.Delete(ctx, finbackup)).Should(Succeed())
+			})
 
-			deletionJobKey := types.NamespacedName{Name: deletionJobName(finbackup), Namespace: namespace}
-			var deletionJob batchv1.Job
-			err = k8sClient.Get(ctx, deletionJobKey, &deletionJob)
-			Expect(err).Should(HaveOccurred())
-			Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
+			It("should not create any cleanup or deletion jobs", func(ctx SpecContext) {
+				By("reconciling the FinBackup after removing SnapID and adding the deletion timestamp")
+				_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finbackup)})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("checking that the FinBackup is deleted")
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), finbackup)
+				Expect(err).Should(HaveOccurred())
+				Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
+
+				By("checking that no cleanup or deletion jobs are created")
+				cleanupJobKey := types.NamespacedName{Name: cleanupJobName(finbackup), Namespace: namespace}
+				var cleanupJob batchv1.Job
+				err = k8sClient.Get(ctx, cleanupJobKey, &cleanupJob)
+				Expect(err).Should(HaveOccurred())
+				Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
+
+				deletionJobKey := types.NamespacedName{Name: deletionJobName(finbackup), Namespace: namespace}
+				var deletionJob batchv1.Job
+				err = k8sClient.Get(ctx, deletionJobKey, &deletionJob)
+				Expect(err).Should(HaveOccurred())
+				Expect(k8serrors.IsNotFound(err)).Should(BeTrue())
+			})
 		})
 	})
 })


### PR DESCRIPTION
- test: ensure no cleanup and deletion jobs are created when deleting a FinBackup without SnapID
- test: ensure no backup job is created when creating a FinBackup with a SnapID