### PR TITLE
controller: Prevent updating immutable fields in CreateOrUpdate

### DIFF
--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -599,6 +599,12 @@ func (r *FinBackupReconciler) createOrUpdateBackupJob(
 		annotations[annotationFinBackupNamespace] = backup.GetNamespace()
 		job.SetAnnotations(annotations)
 
+		// Up to this point, we modify the mutable fields. From here on, we
+		// modify the immutable fields, which cannot be changed after creation.
+		if !job.CreationTimestamp.IsZero() {
+			return nil
+		}
+
 		job.Spec.BackoffLimit = ptr.To(int32(maxJobBackoffLimit))
 
 		job.Spec.Template.Spec.NodeName = backup.Spec.Node
@@ -782,6 +788,12 @@ func (r *FinBackupReconciler) createOrUpdateDeletionJob(ctx context.Context, bac
 		labels["app.kubernetes.io/component"] = labelComponentDeletionJob
 		job.SetLabels(labels)
 
+		// Up to this point, we modify the mutable fields. From here on, we
+		// modify the immutable fields, which cannot be changed after creation.
+		if !job.CreationTimestamp.IsZero() {
+			return nil
+		}
+
 		job.Spec.BackoffLimit = ptr.To(int32(maxJobBackoffLimit))
 
 		job.Spec.Template.Spec.NodeName = backup.Spec.Node
@@ -862,6 +874,12 @@ func (r *FinBackupReconciler) createOrUpdateCleanupJob(ctx context.Context, back
 		labels["app.kubernetes.io/name"] = labelAppNameValue
 		labels["app.kubernetes.io/component"] = labelComponentCleanupJob
 		job.SetLabels(labels)
+
+		// Up to this point, we modify the mutable fields. From here on, we
+		// modify the immutable fields, which cannot be changed after creation.
+		if !job.CreationTimestamp.IsZero() {
+			return nil
+		}
 
 		job.Spec.BackoffLimit = ptr.To(int32(maxJobBackoffLimit))
 


### PR DESCRIPTION
Immutable fields cannot be updated once the resource has been created.
However, the current implementation may update these fields in
CreateOrUpdate, since some of them are set based on controller inputs
like r.podImage and r.rawImgExpansionUnitSize, which can change if the
controller is restarted.

This commit addresses the issue by checking the creationTimestamp in the
CreateOrUpdate handler. If the timestamp is non-zero (indicating the
resource already exists and is being updated rather than created), the
handler returns early without modifying any immutable fields.