### PR TITLE
e2e: enrich minikube spec

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -63,8 +63,8 @@ launch-minikube: $(MINIKUBE) $(KUBECTL)
 		$(MINIKUBE) start \
 			--kubernetes-version="v$(KUBERNETES_VERSION)" \
 			--driver=kvm2 \
-			--memory 6g \
-			--cpus=2 \
+			--memory 10g \
+			--cpus=3 \
 			--extra-config=kubeadm.node-name=$(NODE_NAME) \
 			--extra-config=kubelet.hostname-override=$(NODE_NAME); \
 	fi


### PR DESCRIPTION
Sometimes launching osd takes too long time. Try enriching minikube spec to distinguish whether this problem comes from resource outage.

The risk of incurring new problem caused by other resource outage would not be high since most workloads run
inside minikube.