### PR TITLE
e2e: remove dotnet directory to free up disk space

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
+
+      - name: Free up disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet
+          df -h /
+
       - name: KVM setup
         run: |
           VIRTUALIZATION_SUPPORT=$(grep -E -q 'vmx|svm' /proc/cpuinfo && echo yes || echo no)


### PR DESCRIPTION
free up disk space to avoid the `System.IO.IOException: No space left on device` error.

ref: https://github.com/cybozu-go/fin/actions/runs/18023931425