### PR TITLE
fix: rename SyncedToNode to StoredToNode

### DIFF
--- a/api/v1/finbackup_types.go
+++ b/api/v1/finbackup_types.go
@@ -51,7 +51,7 @@ type FinBackupStatus struct {
 }
 
 const (
-	BackupConditionSyncedToNode = "SyncedToNode"
+	BackupConditionStoredToNode = "StoredToNode"
 )
 
 //+kubebuilder:object:root=true
@@ -77,8 +77,8 @@ type FinBackupList struct {
 	Items           []FinBackup `json:"items"`
 }
 
-func (fb *FinBackup) IsSyncedToNode() bool {
-	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionSyncedToNode)
+func (fb *FinBackup) IsStoredToNode() bool {
+	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionStoredToNode)
 }
 
 func init() {

--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -136,7 +136,7 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.reconcileDelete(ctx, &backup)
 	}
 
-	if backup.IsSyncedToNode() {
+	if backup.IsStoredToNode() {
 		return ctrl.Result{}, nil
 	}
 
@@ -224,7 +224,7 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	updatedBackup := backup.DeepCopy()
 	meta.SetStatusCondition(&updatedBackup.Status.Conditions, metav1.Condition{
-		Type:    finv1.BackupConditionSyncedToNode,
+		Type:    finv1.BackupConditionStoredToNode,
 		Status:  metav1.ConditionTrue,
 		Reason:  "BackupCompleted",
 		Message: "Backup completed successfully",
@@ -507,8 +507,8 @@ func snapIDPreconditionSatisfied(backup *finv1.FinBackup, otherFinBackups []finv
 		if snapID > targetSnapID {
 			continue
 		}
-		if !fb.IsSyncedToNode() && fb.DeletionTimestamp.IsZero() {
-			return fmt.Errorf("found FinBackup not yet synced to node: %s/%d", fb.Name, snapID)
+		if !fb.IsStoredToNode() && fb.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("found FinBackup not yet stored to node: %s/%d", fb.Name, snapID)
 		}
 		smallerIDs++
 		if smallerIDs >= 2 {

--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -107,12 +107,12 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			By("creating a full FinBackup")
 			finbackup1 = NewFinBackup(namespace, "fb1-sample", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
-			MakeFinBackupSyncedToNode(ctx, finbackup1)
+			MakeFinBackupStoredToNode(ctx, finbackup1)
 
 			By("creating a incremental FinBackup")
 			finbackup2 = NewFinBackup(namespace, "fb2-sample", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup2)).Should(Succeed())
-			MakeFinBackupSyncedToNode(ctx, finbackup2)
+			MakeFinBackupStoredToNode(ctx, finbackup2)
 
 			By("deleting the full FinBackup")
 			Expect(k8sClient.Delete(ctx, finbackup1)).Should(Succeed())
@@ -153,19 +153,19 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 
 	// CSATEST-1542
 	// Description:
-	//   FinBackup becomes SyncedToNode when a backup-target PVC is recreated.
+	//   FinBackup becomes StoredToNode when a backup-target PVC is recreated.
 	//
 	// Arrange:
 	//   - Create a backup-target PVC.
-	//   - Create a FinBackup and make it SyncedToNode.
+	//   - Create a FinBackup and make it StoredToNode.
 	//   - Recreate the backup-target PVC.
 	//
 	// Act:
 	//   - Create a new FinBackup.
 	//
 	// Assert:
-	//   - The new FinBackup becomes SyncedToNode.
-	Describe("FinBackup becomes SyncedToNode when a backup-target PVC is recreated", func() {
+	//   - The new FinBackup becomes StoredToNode.
+	Describe("FinBackup becomes StoredToNode when a backup-target PVC is recreated", func() {
 		var pvc1 *corev1.PersistentVolumeClaim
 		var pv1 *corev1.PersistentVolume
 		var finbackup1 *finv1.FinBackup
@@ -179,7 +179,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			By("creating a full FinBackup")
 			finbackup1 = NewFinBackup(namespace, "fb1-1542", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
-			MakeFinBackupSyncedToNode(ctx, finbackup1)
+			MakeFinBackupStoredToNode(ctx, finbackup1)
 
 			By("recreating the backup-target PVC")
 			DeletePVCAndPV(ctx, pvc1.Namespace, pvc1.Name)
@@ -201,9 +201,9 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			DeletePVCAndPV(ctx, pvc1.Namespace, pvc1.Name)
 		})
 
-		It("should make the new FinBackup SyncedToNode", func(ctx SpecContext) {
+		It("should make the new FinBackup StoredToNode", func(ctx SpecContext) {
 			By("waiting for the FinBackup to be ready")
-			MakeFinBackupSyncedToNode(ctx, finbackup2)
+			MakeFinBackupStoredToNode(ctx, finbackup2)
 		})
 	})
 
@@ -214,7 +214,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 	//
 	// Arrange:
 	//   - An RBD PVC exists.
-	//   - A FinBackup as a full backup exists and is SyncedToNode.
+	//   - A FinBackup as a full backup exists and is StoredToNode.
 	//
 	// Act:
 	//   - Create a FinBackup (FB2) as an incremental backup.
@@ -235,12 +235,12 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			By("creating a full FinBackup")
 			finbackup1 = NewFinBackup(namespace, "fb1-1621", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
-			MakeFinBackupSyncedToNode(ctx, finbackup1)
+			MakeFinBackupStoredToNode(ctx, finbackup1)
 
 			By("creating an incremental FinBackup")
 			finbackup2 = NewFinBackup(namespace, "fb2-1621", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup2)).Should(Succeed())
-			MakeFinBackupSyncedToNode(ctx, finbackup2)
+			MakeFinBackupStoredToNode(ctx, finbackup2)
 		})
 
 		AfterEach(func(ctx SpecContext) {
@@ -347,10 +347,10 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
 
-			By("creating FinBackup as a full backup and waiting until it becomes SyncedToNode")
+			By("creating FinBackup as a full backup and waiting until it becomes StoredToNode")
 			finbackup = NewFinBackup(namespace, "fb1-1506", pvc.Name, pvc.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup)).Should(Succeed())
-			MakeFinBackupSyncedToNode(ctx, finbackup)
+			MakeFinBackupStoredToNode(ctx, finbackup)
 
 			By("creating two FinBackups and ordering them by SnapID")
 			fb2 := NewFinBackup(namespace, "fb2-1506", pvc.Name, pvc.Namespace, "test-node")
@@ -783,7 +783,7 @@ func Test_snapIDPreconditionSatisfied(t *testing.T) {
 		if ready {
 			fb.Status.Conditions = []metav1.Condition{
 				{
-					Type:   finv1.BackupConditionSyncedToNode,
+					Type:   finv1.BackupConditionStoredToNode,
 					Status: metav1.ConditionTrue,
 				},
 			}

--- a/internal/controller/finrestore_controller.go
+++ b/internal/controller/finrestore_controller.go
@@ -170,8 +170,8 @@ func (r *FinRestoreReconciler) reconcileCreateOrUpdate(
 		return ctrl.Result{}, nil
 	}
 
-	if !backup.IsSyncedToNode() {
-		logger.Info("backup is not yet synced to node", "backup", backup.Name, "namespace", backup.Namespace)
+	if !backup.IsStoredToNode() {
+		logger.Info("backup is not yet stored to node", "backup", backup.Name, "namespace", backup.Namespace)
 
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -98,7 +98,7 @@ func NewPVCAndPV(
 	}
 	return pvc, pv
 }
-func MakeFinBackupSyncedToNode(ctx context.Context, finbackup *finv1.FinBackup) {
+func MakeFinBackupStoredToNode(ctx context.Context, finbackup *finv1.FinBackup) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
 		key := types.NamespacedName{Name: backupJobName(finbackup), Namespace: namespace}
@@ -113,7 +113,7 @@ func MakeFinBackupSyncedToNode(ctx context.Context, finbackup *finv1.FinBackup) 
 		var createdFinBackup finv1.FinBackup
 		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), &createdFinBackup)
 		g.Expect(err).ShouldNot(HaveOccurred())
-		g.Expect(createdFinBackup.IsSyncedToNode()).Should(BeTrue(), "FinBackup should be ready")
+		g.Expect(createdFinBackup.IsStoredToNode()).Should(BeTrue(), "FinBackup should be ready")
 	}, "5s", "1s").Should(Succeed())
 }
 

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -56,7 +56,7 @@ func backupTestSuite() {
 	//   Create FinBackup, referring the PVC.
 	//
 	// Assert:
-	//   - FinBackup.conditions["SyncedToNode"] is true.
+	//   - FinBackup.conditions["StoredToNode"] is true.
 	//   - the head of the raw.img in the PVC's directory is filled
 	//     with the same data as the head of the PVC.
 	It("should create full backup", func(ctx SpecContext) {
@@ -70,7 +70,7 @@ func backupTestSuite() {
 		Expect(err).NotTo(HaveOccurred())
 		err = CreateFinBackup(ctx, ctrlClient, finbackup)
 		Expect(err).NotTo(HaveOccurred())
-		err = WaitForFinBackupSyncedToNode(ctx, ctrlClient, rookNamespace, finbackup.GetName(), 1*time.Minute)
+		err = WaitForFinBackupStoredToNode(ctx, ctrlClient, rookNamespace, finbackup.GetName(), 1*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the data in raw.img")

--- a/test/e2e/incremental_test.go
+++ b/test/e2e/incremental_test.go
@@ -23,14 +23,14 @@ import (
 //  1. An RBD PVC is created on the Ceph cluster.
 //  2. Random data is written to the RBD PVC.
 //  3. A FinBackup1 that references the PVC
-//     and has the "SyncedToNode" condition set to "True" is created.
+//     and has the "StoredToNode" condition set to "True" is created.
 //  4. New random data is written to the RBD PVC.
 //
 // Act:
 //   - Create FinBackup2 for the incremental backup.
 //
 // Assert:
-//   - The FinBackup2's condition "SyncedToNode" becomes "True".
+//   - The FinBackup2's condition "StoredToNode" becomes "True".
 //   - On the Fin node for the FinBackup2, the backup directory has:
 //     1. raw.img with the data from step 2.
 //     2. A diff file under the diff directory for the incremental backup.
@@ -77,7 +77,7 @@ func incrementalBackupTestSuite() {
 		finbackup1, err = GetFinBackup(rookNamespace, "fb-incremental-1", pvcNamespace, pvc.Name, "minikube-worker")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(CreateFinBackup(ctx, ctrlClient, finbackup1)).NotTo(HaveOccurred())
-		Expect(WaitForFinBackupSyncedToNode(ctx, ctrlClient, rookNamespace, finbackup1.Name, 1*time.Minute)).
+		Expect(WaitForFinBackupStoredToNode(ctx, ctrlClient, rookNamespace, finbackup1.Name, 1*time.Minute)).
 			NotTo(HaveOccurred())
 
 		By("verifying the data in raw.img from the full backup")
@@ -114,7 +114,7 @@ func incrementalBackupTestSuite() {
 		finbackup2, err := GetFinBackup(rookNamespace, "fb-incremental-2", pvcNamespace, pvc.Name, "minikube-worker")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(CreateFinBackup(ctx, ctrlClient, finbackup2)).NotTo(HaveOccurred())
-		Expect(WaitForFinBackupSyncedToNode(ctx, ctrlClient, rookNamespace, finbackup2.Name, 1*time.Minute)).
+		Expect(WaitForFinBackupStoredToNode(ctx, ctrlClient, rookNamespace, finbackup2.Name, 1*time.Minute)).
 			NotTo(HaveOccurred())
 
 		By("verifying the data in raw.img as full backup")

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -77,7 +77,7 @@ func restoreTestSuite() {
 		Expect(err).NotTo(HaveOccurred())
 		err = CreateFinBackup(ctx, ctrlClient, finbackup)
 		Expect(err).NotTo(HaveOccurred())
-		err = WaitForFinBackupSyncedToNode(ctx, ctrlClient, finbackupNamespace, finbackup.Name, 2*time.Minute)
+		err = WaitForFinBackupStoredToNode(ctx, ctrlClient, finbackupNamespace, finbackup.Name, 2*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Act

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -321,7 +321,7 @@ func DeleteFinRestore(ctx context.Context, client client.Client, namespace, name
 	return client.Delete(ctx, finrestore)
 }
 
-func WaitForFinBackupSyncedToNode(ctx context.Context, client client.Client, namespace, name string, timeout time.Duration) error {
+func WaitForFinBackupStoredToNode(ctx context.Context, client client.Client, namespace, name string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		finbackup := &finv1.FinBackup{}
 		err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, finbackup)
@@ -329,7 +329,7 @@ func WaitForFinBackupSyncedToNode(ctx context.Context, client client.Client, nam
 			return false, err
 		}
 
-		return finbackup.IsSyncedToNode(), nil
+		return finbackup.IsStoredToNode(), nil
 	})
 }
 


### PR DESCRIPTION
The commit c7c64af wrongly changes ReadyToUse to SyncedToNode, which is actually StoredToNode. This commit fixes this.