### PR TITLE
finrestore-controller: add tests for Restore PVC naming

### DIFF
--- a/internal/controller/finrestore_controller_test.go
+++ b/internal/controller/finrestore_controller_test.go
@@ -103,4 +103,112 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 			ExpectNoJob(ctx, k8sClient, restoreJobName(finrestore), finrestore.Namespace)
 		})
 	})
+
+	// CSATEST-1560
+	// Description:
+	//   Restore with specifying Restore PVC name and namespace.
+	//
+	// Arrange:
+	//   - A backup-target PVC exists.
+	//   - FinBackup referencing the PVC exists and is StoredToNode.
+	//
+	// Act:
+	//   - Create FinRestore referencing the FinBackup.
+	//       - The FinRestore specifies spec.pvc and spec.pvcNamespace different from status.pvcManifest.
+	//
+	// Assert:
+	//   - Reconcile() does not return an error.
+	//   - Restore PVC exists with the spec.pvcName and spec.pvcNamespace of FinRestore.
+	Context("Restore with specifying Restore PVC name and namespace", func() {
+		var pvc *corev1.PersistentVolumeClaim
+		var pv *corev1.PersistentVolume
+		var finbackup *finv1.FinBackup
+		var finrestore *finv1.FinRestore
+
+		BeforeEach(func(ctx SpecContext) {
+			By("creating PVC and PV")
+			pvc, pv = NewPVCAndPV(sc, namespace, "test-pvc-1560", "test-pv-1560", rbdImageName)
+			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
+
+			By("creating FinBackup targeting the PVC")
+			finbackup = CreateFinBackupStored(ctx, k8sClient, namespace, "test-fin-backup-1560", pvc, 1, "test-node")
+
+			By("Creating a FinRestore with a PVC of a different name and namespace.")
+			finrestore = NewFinRestore(namespace, "test-restore-1560", finbackup.Name, "restore-pvc", otherNamespace.Name)
+			Expect(k8sClient.Create(ctx, finrestore)).Should(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, finrestore)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, finbackup)).Should(Succeed())
+			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
+			DeletePVCAndPV(ctx, finrestore.Spec.PVCNamespace, finrestore.Spec.PVC)
+		})
+
+		It("should complete reconciliation and create restore PVC with specified name", func(ctx SpecContext) {
+			By("reconciling the FinRestore")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finrestore)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("checking that restore PVC is created with specified name")
+			var restorePVC corev1.PersistentVolumeClaim
+			key := client.ObjectKey{Namespace: finrestore.Spec.PVCNamespace, Name: finrestore.Spec.PVC}
+			Expect(k8sClient.Get(ctx, key, &restorePVC)).Should(Succeed())
+		})
+	})
+
+	// CSATEST-1623
+	// Description:
+	//   Restore without specifying Restore PVC name and namespace
+	//
+	// Arrange:
+	//   - A backup-target PVC exists.
+	//   - FinBackup referencing the PVC exists and is StoredToNode.
+	//
+	// Act:
+	//   - Create FinRestore referencing the FinBackup.
+	//   - The FinRestore specifies spec.pvc and spec.pvcNamespace different from status.pvcManifest.
+	//
+	// Assert:
+	//   - Reconcile() does not return an error.
+	//   - Restore PVC exists with the same name and namespace as FinRestore.
+	Context("Restore without specifying FinRestore PVC name and namespace", func() {
+		var pvc *corev1.PersistentVolumeClaim
+		var pv *corev1.PersistentVolume
+		var finbackup *finv1.FinBackup
+		var finrestore *finv1.FinRestore
+
+		BeforeEach(func(ctx SpecContext) {
+			By("creating PVC and PV")
+			pvc, pv = NewPVCAndPV(sc, namespace, "test-pvc-1623", "test-pv-1623", rbdImageName)
+			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
+
+			By("creating FinBackup targeting the PVC")
+			finbackup = CreateFinBackupStored(ctx, k8sClient, namespace, "test-fin-backup-1623", pvc, 1, "test-node")
+
+			By("creating FinRestore without specifying PVC name and namespace")
+			finrestore = NewFinRestore(namespace, "test-restore-1623", finbackup.Name, "", "")
+			Expect(k8sClient.Create(ctx, finrestore)).Should(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, finrestore)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, finbackup)).Should(Succeed())
+			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
+			DeletePVCAndPV(ctx, finrestore.Namespace, finrestore.Name)
+		})
+
+		It("should complete reconciliation and create restore PVC with default name", func(ctx SpecContext) {
+			By("reconciling the FinRestore")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finrestore)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("checking that restore PVC is created with default name")
+			var restorePVC corev1.PersistentVolumeClaim
+			key := client.ObjectKey{Namespace: finrestore.Namespace, Name: finrestore.Name}
+			Expect(k8sClient.Get(ctx, key, &restorePVC)).Should(Succeed())
+		})
+	})
 })

--- a/internal/controller/finrestore_controller_test.go
+++ b/internal/controller/finrestore_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, finbackup)).Should(Succeed())
 
 			By("creating a FinRestore targeting the FinBackup")
-			finrestore = NewFinRestore(namespace, "test-restore-1", finbackup)
+			finrestore = NewFinRestore(namespace, "test-restore-1", finbackup.Name, "restore-pvc", pvc2.Namespace)
 			Expect(k8sClient.Create(ctx, finrestore)).Should(Succeed())
 		})
 

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -152,6 +154,9 @@ func DeletePVCAndPV(ctx context.Context, namespace, pvcName string) {
 		Expect(k8sClient.Delete(ctx, &pvc)).Should(Succeed())
 	}
 
+	if pvc.Spec.VolumeName == "" {
+		return
+	}
 	var pv corev1.PersistentVolume
 	err = k8sClient.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, &pv)
 	if k8serrors.IsNotFound(err) {
@@ -239,4 +244,30 @@ func createTwoBackupsOrdered(
 		}
 	}, "5s", "1s").Should(Succeed())
 	return smaller, larger
+}
+
+func CreateFinBackupStored(
+	ctx context.Context,
+	c client.Client,
+	namespace, name string,
+	pvc *corev1.PersistentVolumeClaim,
+	snapID int,
+	testNode string,
+) *finv1.FinBackup {
+	GinkgoHelper()
+
+	finbackup := NewFinBackup(namespace, name, pvc.Name, pvc.Namespace, testNode)
+	Expect(c.Create(ctx, finbackup)).Should(Succeed())
+	pvcManifest, err := json.Marshal(pvc)
+	Expect(err).ShouldNot(HaveOccurred())
+	finbackup.Status.SnapSize = ptr.To(pvc.Spec.Resources.Requests.Storage().Value())
+	finbackup.Status.SnapID = ptr.To(snapID)
+	finbackup.Status.PVCManifest = string(pvcManifest)
+	meta.SetStatusCondition(&finbackup.Status.Conditions, metav1.Condition{
+		Type:   finv1.BackupConditionStoredToNode,
+		Status: metav1.ConditionTrue,
+		Reason: "BackupCompleted",
+	})
+	Expect(c.Status().Update(ctx, finbackup)).Should(Succeed())
+	return finbackup
 }

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -201,16 +201,16 @@ func NewFinBackup(namespace, name, pvc, pvcNS, node string) *finv1.FinBackup {
 	}
 }
 
-func NewFinRestore(namespace, name string, fb *finv1.FinBackup) *finv1.FinRestore {
+func NewFinRestore(namespace, name string, fbName, pvc, pvcNamespace string) *finv1.FinRestore {
 	return &finv1.FinRestore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 		Spec: finv1.FinRestoreSpec{
-			PVC:          fb.Spec.PVC,
-			PVCNamespace: fb.Spec.PVCNamespace,
-			Backup:       fb.Name,
+			PVC:          pvc,
+			PVCNamespace: pvcNamespace,
+			Backup:       fbName,
 		},
 	}
 }


### PR DESCRIPTION
refactor test code
- use default expansionUnitSize
- explicitly specify Restore PVC in NewFinRestore

add test cases
- create Restore PVC with the expected name