### PR TITLE
controller: add finbackupconfig controller and createfinbackup subcommand

### DIFF
--- a/cmd/createfinbackup.go
+++ b/cmd/createfinbackup.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/cybozu-go/fin/internal/job/createfinbackup"
+	"github.com/cybozu-go/fin/internal/job/input"
+	"github.com/spf13/cobra"
+)
+
+var createFinBackupCmd = &cobra.Command{
+	Use: "createfinbackup",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return createFinBackupJobMain()
+	},
+}
+
+var (
+	fbcName      string
+	fbcNamespace string
+)
+
+func init() {
+	createFinBackupCmd.Flags().StringVar(&fbcName, "fin-backup-config-name", "", "FinBackupConfig name")
+	createFinBackupCmd.Flags().StringVar(&fbcNamespace, "fin-backup-config-namespace", "", "FinBackupConfig namespace")
+	rootCmd.AddCommand(createFinBackupCmd)
+}
+
+func createFinBackupJobMain() error {
+	if fbcName == "" {
+		return fmt.Errorf("--fin-backup-config-name is required")
+	}
+	if fbcNamespace == "" {
+		return fmt.Errorf("--fin-backup-config-namespace is required")
+	}
+
+	jobName := os.Getenv("JobName")
+	if jobName == "" {
+		return fmt.Errorf("JobName environment variable is not set")
+	}
+	jobCreatedAtStr := os.Getenv("JobCreationTimestamp")
+	if jobCreatedAtStr == "" {
+		return fmt.Errorf("JobCreationTimestamp environment variable is not set")
+	}
+	jobCreatedAt, err := time.Parse(time.RFC3339, jobCreatedAtStr)
+	if err != nil {
+		return fmt.Errorf("invalid JobCreationTimestamp: %w", err)
+	}
+
+	k8sClient, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create controller client: %w", err)
+	}
+
+	in := &input.CreateFinBackup{
+		FinBackupConfigName:         fbcName,
+		FinBackupConfigNamespace:    fbcNamespace,
+		CurrentJobName:              jobName,
+		CurrentJobCreationTimestamp: jobCreatedAt,
+		CtrlClient:                  k8sClient,
+	}
+	c := createfinbackup.NewCreateFinBackup(in)
+	if err := c.Perform(); err != nil {
+		slog.Error("create-finbackup failed", "err", err)
+		return err
+	}
+	slog.Info("create-finbackup-job completed successfully")
+	return nil
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,8 +3,12 @@ package cmd
 import (
 	"fmt"
 
+	finv1 "github.com/cybozu-go/fin/api/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func getClientSet() (*kubernetes.Clientset, error) {
@@ -17,4 +21,25 @@ func getClientSet() (*kubernetes.Clientset, error) {
 		return nil, fmt.Errorf("failed to create Kubernetes clientset: %w", err)
 	}
 	return clientSet, nil
+}
+
+func getControllerClient() (client.Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get in-cluster config: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add client-go scheme: %w", err)
+	}
+	if err := finv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add fin v1 scheme: %w", err)
+	}
+
+	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create controller-runtime client: %w", err)
+	}
+	return k8sClient, nil
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,7 @@ rules:
 - apiGroups:
   - batch
   resources:
+  - cronjobs
   - jobs
   verbs:
   - create

--- a/internal/controller/finbackupconfig_controller.go
+++ b/internal/controller/finbackupconfig_controller.go
@@ -2,34 +2,57 @@ package controller
 
 import (
 	"context"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
 
 	finv1 "github.com/cybozu-go/fin/api/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var errEmptyClusterID error = errors.New("cluster ID is empty")
 
 // FinBackupConfigReconciler reconciles a FinBackupConfig object
 type FinBackupConfigReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme               *runtime.Scheme
+	finCephClusterID     string
+	overwriteFBCSchedule string
 }
+
+const (
+	defaultStartingDeadlineSeconds int64 = 3600
+	maxBackoffLimit                int32 = 65535
+)
 
 func NewFinBackupConfigReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
+	overwriteFBCSchedule string,
 ) *FinBackupConfigReconciler {
 	return &FinBackupConfigReconciler{
-		Client: client,
-		Scheme: scheme,
+		Client:               client,
+		Scheme:               scheme,
+		overwriteFBCSchedule: overwriteFBCSchedule,
 	}
 }
 
 //+kubebuilder:rbac:groups=fin.cybozu.io,resources=finbackupconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fin.cybozu.io,resources=finbackupconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fin.cybozu.io,resources=finbackupconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -41,9 +64,41 @@ func NewFinBackupConfigReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
 func (r *FinBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	var fbc finv1.FinBackupConfig
+	if err := r.Get(ctx, req.NamespacedName, &fbc); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	var pvc corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, types.NamespacedName{Namespace: fbc.Namespace, Name: fbc.Spec.PVC}, &pvc); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get PVC %s/%s: %w", fbc.Namespace, fbc.Spec.PVC, err)
+	}
+
+	clusterID, err := getCephClusterIDFromPVC(ctx, r.Client, &pvc)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Ceph cluster ID: %s: %s: %w", fbc.Namespace, fbc.Spec.PVC, err)
+	}
+	if clusterID != r.finCephClusterID {
+		logger.Info("the target pvc is not managed by this controller")
+		return ctrl.Result{}, nil
+	}
+
+	pod, err := getRunningPod(ctx, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get running pod: %w", err)
+	}
+	if len(pod.Spec.Containers) == 0 {
+		return ctrl.Result{}, fmt.Errorf("running pod has no containers")
+	}
+	image := pod.Spec.Containers[0].Image
+
+	serviceAccountName := os.Getenv("CREATE_FINBACKUP_JOB_SERVICE_ACCOUNT")
+
+	if err := r.createOrUpdateCronJob(ctx, &fbc, fbc.Namespace, serviceAccountName, image); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create or update CronJob: %w", err)
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -52,5 +107,156 @@ func (r *FinBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *FinBackupConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&finv1.FinBackupConfig{}).
+		Owns(&batchv1.CronJob{}).
 		Complete(r)
+}
+
+func getCephClusterIDFromSCName(ctx context.Context, k8sClient client.Client, storageClassName string) (string, error) {
+	var storageClass storagev1.StorageClass
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: storageClassName}, &storageClass)
+	if err != nil {
+		return "", fmt.Errorf("failed to get StorageClass: %s: %w", storageClassName, err)
+	}
+
+	if !strings.HasSuffix(storageClass.Provisioner, ".rbd.csi.ceph.com") {
+		return "", fmt.Errorf("SC is not managed by RBD: %s: %w", storageClassName, errEmptyClusterID)
+	}
+	clusterID, ok := storageClass.Parameters["clusterID"]
+	if !ok {
+		return "", fmt.Errorf("clusterID not found: %s: %w", storageClassName, errEmptyClusterID)
+	}
+
+	return clusterID, nil
+}
+
+func getCephClusterIDFromPVC(
+	ctx context.Context,
+	k8sClient client.Client,
+	pvc *corev1.PersistentVolumeClaim,
+) (string, error) {
+	logger := log.FromContext(ctx)
+
+	storageClassName := pvc.Spec.StorageClassName
+	if storageClassName == nil {
+		logger.Info("not managed storage class", "namespace", pvc.Namespace, "pvc", pvc.Name)
+		return "", nil
+	}
+
+	clusterID, err := getCephClusterIDFromSCName(ctx, k8sClient, *storageClassName)
+	if err != nil {
+		logger.Info("failed to get ceph cluster ID from StorageClass name",
+			"error", err, "namespace", pvc.Namespace, "pvc", pvc.Name, "storageClassName", *storageClassName)
+		if errors.Is(err, errEmptyClusterID) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	return clusterID, nil
+}
+
+func getRunningPod(ctx context.Context, client client.Client) (*corev1.Pod, error) {
+	name, ok := os.LookupEnv("POD_NAME")
+	if !ok {
+		return nil, fmt.Errorf("POD_NAME not found")
+	}
+	namespace, ok := os.LookupEnv("POD_NAMESPACE")
+	if !ok {
+		return nil, fmt.Errorf("POD_NAMESPACE not found")
+	}
+	var pod corev1.Pod
+	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &pod); err != nil {
+		return nil, fmt.Errorf("failed to get pod: %w", err)
+	}
+	return &pod, nil
+}
+
+func setEnvFromFieldRef(container *corev1.Container, envName, fieldPath string) {
+	envIndex := slices.IndexFunc(container.Env, func(e corev1.EnvVar) bool {
+		return e.Name == envName
+	})
+	if envIndex == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{Name: envName})
+		envIndex = len(container.Env) - 1
+	}
+	env := &container.Env[envIndex]
+	if env.ValueFrom == nil {
+		env.ValueFrom = &corev1.EnvVarSource{}
+	}
+	if env.ValueFrom.FieldRef == nil {
+		env.ValueFrom.FieldRef = &corev1.ObjectFieldSelector{}
+	}
+	env.ValueFrom.FieldRef.FieldPath = fieldPath
+}
+
+func (r *FinBackupConfigReconciler) createOrUpdateCronJob(
+	ctx context.Context,
+	fbc *finv1.FinBackupConfig,
+	namespace string,
+	serviceAccountName string,
+	image string,
+) error {
+	logger := log.FromContext(ctx)
+	cronJobName := "fbc-" + string(fbc.UID)
+
+	cronJob := &batchv1.CronJob{}
+	cronJob.SetName(cronJobName)
+	cronJob.SetNamespace(namespace)
+
+	op, err := ctrl.CreateOrUpdate(ctx, r.Client, cronJob, func() error {
+		cronJob.Spec.Schedule = fbc.Spec.Schedule
+		if r.overwriteFBCSchedule != "" {
+			cronJob.Spec.Schedule = r.overwriteFBCSchedule
+		}
+		cronJob.Spec.Suspend = &fbc.Spec.Suspend
+		cronJob.Spec.StartingDeadlineSeconds = func() *int64 { v := defaultStartingDeadlineSeconds; return &v }()
+		cronJob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
+		cronJob.Spec.JobTemplate.Spec.BackoffLimit = func() *int32 { v := maxBackoffLimit; return &v }()
+
+		// Set Job creation timestamp as RFC3339 string into PodTemplate annotations
+		creationTime := metav1.Now().Format(time.RFC3339)
+		if cronJob.Spec.JobTemplate.Annotations == nil {
+			cronJob.Spec.JobTemplate.Annotations = make(map[string]string)
+		}
+		cronJob.Spec.JobTemplate.Annotations["job.k8s.io/created-at"] = creationTime
+		if cronJob.Spec.JobTemplate.Spec.Template.Annotations == nil {
+			cronJob.Spec.JobTemplate.Spec.Template.Annotations = make(map[string]string)
+		}
+		cronJob.Spec.JobTemplate.Spec.Template.Annotations["job.k8s.io/created-at"] = creationTime
+
+		podSpec := &cronJob.Spec.JobTemplate.Spec.Template.Spec
+		podSpec.ServiceAccountName = serviceAccountName
+		podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
+
+		if len(podSpec.Containers) == 0 {
+			podSpec.Containers = make([]corev1.Container, 1)
+		}
+		container := &podSpec.Containers[0]
+		container.Name = "create-finbackup-job"
+		container.Image = image
+		container.ImagePullPolicy = corev1.PullIfNotPresent
+		container.Command = []string{
+			"/fin-controller",
+			"create-finbackup-job",
+			"--fin-backup-config-name=" + fbc.GetName(),
+			"--fin-backup-config-namespace=" + fbc.GetNamespace(),
+		}
+
+		// Set environment variables using the Downward API.
+		setEnvFromFieldRef(container, "JobName", "metadata.labels['batch.kubernetes.io/job-name']")
+		setEnvFromFieldRef(container, "JobCreationTimestamp", "metadata.annotations['job.k8s.io/created-at']")
+
+		if err := controllerutil.SetControllerReference(fbc, cronJob, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set owner reference on CronJob: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create CronJob: %s: %w", cronJobName, err)
+	}
+	if op != controllerutil.OperationResultNone {
+		logger.Info(fmt.Sprintf("CronJob successfully created or updated: %s", cronJobName))
+	}
+	return nil
 }


### PR DESCRIPTION
This pull request adds the FinBackupConfig controller and the create-finbackup-job subcommand. The FinBackupConfig controller periodically creates FinBackup resources  by running the `createfinbackupjob` subcommand through CronJobs. This PR does not include new tests for validation. They will be added in a subsequent pull request.