### PR TITLE
controller: handle verification Job

### DIFF
--- a/api/v1/finbackup_types.go
+++ b/api/v1/finbackup_types.go
@@ -51,7 +51,9 @@ type FinBackupStatus struct {
 }
 
 const (
-	BackupConditionStoredToNode = "StoredToNode"
+	BackupConditionStoredToNode        = "StoredToNode"
+	BackupConditionVerified            = "Verified"
+	BackupConditionVerificationSkipped = "VerificationSkipped"
 )
 
 //+kubebuilder:object:root=true
@@ -79,6 +81,27 @@ type FinBackupList struct {
 
 func (fb *FinBackup) IsStoredToNode() bool {
 	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionStoredToNode)
+}
+
+func (fb *FinBackup) DoesVerifiedExist() bool {
+	return meta.FindStatusCondition(fb.Status.Conditions, BackupConditionVerified) != nil
+}
+
+func (fb *FinBackup) IsVerifiedTrue() bool {
+	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionVerified)
+}
+
+func (fb *FinBackup) IsVerifiedFalse() bool {
+	return meta.IsStatusConditionFalse(fb.Status.Conditions, BackupConditionVerified)
+}
+
+func (fb *FinBackup) IsVerificationSkipped() bool {
+	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionVerificationSkipped)
+}
+
+func (fb *FinBackup) CanBeRestored(allowUnverified bool) bool {
+	return fb.IsStoredToNode() &&
+		(fb.IsVerifiedTrue() || (fb.IsVerificationSkipped() && allowUnverified))
 }
 
 func init() {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -108,11 +108,13 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			finbackup1 = NewFinBackup(namespace, "fb1-sample", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
 			MakeFinBackupStoredToNode(ctx, finbackup1)
+			MakeFinBackupVerified(ctx, finbackup1)
 
 			By("creating a incremental FinBackup")
 			finbackup2 = NewFinBackup(namespace, "fb2-sample", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup2)).Should(Succeed())
 			MakeFinBackupStoredToNode(ctx, finbackup2)
+			MakeFinBackupVerified(ctx, finbackup2)
 
 			By("deleting the full FinBackup")
 			Expect(k8sClient.Delete(ctx, finbackup1)).Should(Succeed())
@@ -180,6 +182,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			finbackup1 = NewFinBackup(namespace, "fb1-1542", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
 			MakeFinBackupStoredToNode(ctx, finbackup1)
+			MakeFinBackupVerified(ctx, finbackup1)
 
 			By("recreating the backup-target PVC")
 			DeletePVCAndPV(ctx, pvc1.Namespace, pvc1.Name)
@@ -204,6 +207,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 		It("should make the new FinBackup StoredToNode", func(ctx SpecContext) {
 			By("waiting for the FinBackup to be ready")
 			MakeFinBackupStoredToNode(ctx, finbackup2)
+			MakeFinBackupVerified(ctx, finbackup2)
 		})
 	})
 
@@ -236,11 +240,13 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			finbackup1 = NewFinBackup(namespace, "fb1-1621", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
 			MakeFinBackupStoredToNode(ctx, finbackup1)
+			MakeFinBackupVerified(ctx, finbackup1)
 
 			By("creating an incremental FinBackup")
 			finbackup2 = NewFinBackup(namespace, "fb2-1621", pvc1.Name, pvc1.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup2)).Should(Succeed())
 			MakeFinBackupStoredToNode(ctx, finbackup2)
+			MakeFinBackupVerified(ctx, finbackup2)
 		})
 
 		AfterEach(func(ctx SpecContext) {
@@ -351,6 +357,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			finbackup = NewFinBackup(namespace, "fb1-1506", pvc.Name, pvc.Namespace, "test-node")
 			Expect(k8sClient.Create(ctx, finbackup)).Should(Succeed())
 			MakeFinBackupStoredToNode(ctx, finbackup)
+			MakeFinBackupVerified(ctx, finbackup)
 
 			By("creating two FinBackups and ordering them by SnapID")
 			fb2 := NewFinBackup(namespace, "fb2-1506", pvc.Name, pvc.Namespace, "test-node")
@@ -784,6 +791,10 @@ func Test_snapIDPreconditionSatisfied(t *testing.T) {
 			fb.Status.Conditions = []metav1.Condition{
 				{
 					Type:   finv1.BackupConditionStoredToNode,
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   finv1.BackupConditionVerified,
 					Status: metav1.ConditionTrue,
 				},
 			}

--- a/internal/controller/finrestore_controller_test.go
+++ b/internal/controller/finrestore_controller_test.go
@@ -135,7 +135,7 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
 
 			By("creating FinBackup targeting the PVC")
-			finbackup = CreateFinBackupStored(ctx, k8sClient, namespace, "test-fin-backup-1560", pvc, 1, "test-node")
+			finbackup = CreateFinBackupStoredAndVerified(ctx, k8sClient, namespace, "test-fin-backup-1560", pvc, 1, "test-node")
 
 			By("Creating a FinRestore with a PVC of a different name and namespace.")
 			finrestore = NewFinRestore(namespace, "test-restore-1560", finbackup.Name, "restore-pvc", otherNamespace.Name)
@@ -189,7 +189,7 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
 
 			By("creating FinBackup targeting the PVC")
-			finbackup = CreateFinBackupStored(ctx, k8sClient, namespace, "test-fin-backup-1623", pvc, 1, "test-node")
+			finbackup = CreateFinBackupStoredAndVerified(ctx, k8sClient, namespace, "test-fin-backup-1623", pvc, 1, "test-node")
 
 			By("creating FinRestore without specifying PVC name and namespace")
 			finrestore = NewFinRestore(namespace, "test-restore-1623", finbackup.Name, "", "")
@@ -333,7 +333,7 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, pv2)).Should(Succeed())
 
 			By("creating FinBackup targeting the PVC1")
-			finbackup = CreateFinBackupStored(ctx, k8sClient, namespace, "test-fin-backup-1558", pvc1, 1, "test-node")
+			finbackup = CreateFinBackupStoredAndVerified(ctx, k8sClient, namespace, "test-fin-backup-1558", pvc1, 1, "test-node")
 
 			By("creating FinRestore targeting the FinBackup with conflicting PVC name")
 			finrestore = NewFinRestore(namespace, "test-restore-1558-1", finbackup.Name, pvc2.Name, pvc2.Namespace)
@@ -390,7 +390,7 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
 
 			By("creating FinBackup and making it StoredToNode")
-			finbackup = CreateFinBackupStored(ctx, k8sClient, namespace, "test-fin-backup-1553", pvc, 1, "test-node")
+			finbackup = CreateFinBackupStoredAndVerified(ctx, k8sClient, namespace, "test-fin-backup-1553", pvc, 1, "test-node")
 
 			By("creating FinRestore targeting the FinBackup")
 			finrestore = NewFinRestore(namespace, "test-restore-1553", finbackup.Name, "restore-pvc-1553", namespace)

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -70,7 +70,7 @@ func backupTestSuite() {
 		Expect(err).NotTo(HaveOccurred())
 		err = CreateFinBackup(ctx, ctrlClient, finbackup)
 		Expect(err).NotTo(HaveOccurred())
-		err = WaitForFinBackupStoredToNode(ctx, ctrlClient, rookNamespace, finbackup.GetName(), 1*time.Minute)
+		err = WaitForFinBackupStoredToNodeAndVerified(ctx, ctrlClient, rookNamespace, finbackup.GetName(), 1*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the data in raw.img")

--- a/test/e2e/incremental_test.go
+++ b/test/e2e/incremental_test.go
@@ -77,7 +77,7 @@ func incrementalBackupTestSuite() {
 		finbackup1, err = GetFinBackup(rookNamespace, "fb-incremental-1", pvcNamespace, pvc.Name, "minikube-worker")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(CreateFinBackup(ctx, ctrlClient, finbackup1)).NotTo(HaveOccurred())
-		Expect(WaitForFinBackupStoredToNode(ctx, ctrlClient, rookNamespace, finbackup1.Name, 1*time.Minute)).
+		Expect(WaitForFinBackupStoredToNodeAndVerified(ctx, ctrlClient, rookNamespace, finbackup1.Name, 1*time.Minute)).
 			NotTo(HaveOccurred())
 
 		By("verifying the data in raw.img from the full backup")
@@ -114,7 +114,7 @@ func incrementalBackupTestSuite() {
 		finbackup2, err := GetFinBackup(rookNamespace, "fb-incremental-2", pvcNamespace, pvc.Name, "minikube-worker")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(CreateFinBackup(ctx, ctrlClient, finbackup2)).NotTo(HaveOccurred())
-		Expect(WaitForFinBackupStoredToNode(ctx, ctrlClient, rookNamespace, finbackup2.Name, 1*time.Minute)).
+		Expect(WaitForFinBackupStoredToNodeAndVerified(ctx, ctrlClient, rookNamespace, finbackup2.Name, 1*time.Minute)).
 			NotTo(HaveOccurred())
 
 		By("verifying the data in raw.img as full backup")

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -77,7 +77,7 @@ func restoreTestSuite() {
 		Expect(err).NotTo(HaveOccurred())
 		err = CreateFinBackup(ctx, ctrlClient, finbackup)
 		Expect(err).NotTo(HaveOccurred())
-		err = WaitForFinBackupStoredToNode(ctx, ctrlClient, finbackupNamespace, finbackup.Name, 2*time.Minute)
+		err = WaitForFinBackupStoredToNodeAndVerified(ctx, ctrlClient, finbackupNamespace, finbackup.Name, 2*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Act

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -321,7 +321,7 @@ func DeleteFinRestore(ctx context.Context, client client.Client, namespace, name
 	return client.Delete(ctx, finrestore)
 }
 
-func WaitForFinBackupStoredToNode(ctx context.Context, client client.Client, namespace, name string, timeout time.Duration) error {
+func WaitForFinBackupStoredToNodeAndVerified(ctx context.Context, client client.Client, namespace, name string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		finbackup := &finv1.FinBackup{}
 		err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, finbackup)
@@ -329,7 +329,7 @@ func WaitForFinBackupStoredToNode(ctx context.Context, client client.Client, nam
 			return false, err
 		}
 
-		return finbackup.IsStoredToNode(), nil
+		return finbackup.IsStoredToNode() && finbackup.IsVerifiedTrue(), nil
 	})
 }
 


### PR DESCRIPTION
This commit updates the reconcilers of FinBackup and FinRestore to handle verification Jobs. More concretely:

- FinBackup's reconciler now reconciles verification Jobs. It creates a verification Job after the backup data is stored on the node, waits for it to complete (or fail), and updates the conditions of the FinBackup resource according to the Job's result.
- FinRestore's reconciler now checks whether the FinBackup being restored is verified. If it's not verified and .spec.allowUnverified of the FinRestore resource is not true, the reconciler won't start its restoration.

The existing tests are also updated to pass. However, this commit does NOT add any new tests to check the verification process, because they'll be added in subsequent commits.