### PR TITLE
ci: fix release workflow for new version of docker-build target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           go-version-file: "go.mod"
 
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - run: make docker-build IMG=ghcr.io/cybozu-go/fin:${{ steps.check_version.outputs.version }}
+      - run: make docker-build IMG=ghcr.io/cybozu-go/fin TAG=${{ steps.check_version.outputs.version }}
       - run: docker push ghcr.io/cybozu-go/fin:${{ steps.check_version.outputs.version }}
 
       - name: "Push branch tag"


### PR DESCRIPTION
Currently .github/workflows/release.yaml uses `make docker-build` with `IMG=ghcr.io/cybozu-go/fin:${{ steps.check_version.outputs.version }}`. However, this is incorrect due to #110, and the workflow fails like the following:

https://github.com/cybozu-go/fin/actions/runs/18519617954/job/52776638770

```
2025-10-15T06:14:34.6748428Z [36;1mmake docker-build IMG=ghcr.io/cybozu-go/fin:0.3.0[0m
2025-10-15T06:14:34.6782028Z shell: /usr/bin/bash -e {0}
2025-10-15T06:14:34.6782253Z ##[endgroup]
2025-10-15T06:14:34.7166873Z docker build -t ghcr.io/cybozu-go/fin:0.3.0:latest .
2025-10-15T06:14:35.2081831Z ERROR: failed to build: invalid tag "ghcr.io/cybozu-go/fin:0.3.0:latest": invalid reference format
2025-10-15T06:14:35.2117825Z make: *** [Makefile:132: docker-build] Error 1
2025-10-15T06:14:35.2132944Z ##[error]Process completed with exit code 2.
```


This PR fixes this problem by using `TAG` argument.

In addition, this PR adds `workflow_dispatch` to the release.yaml so that we will be able to release v0.3.0 by running it manually after this PR is merged.