### PR TITLE
e2e: remove ghcup directory to free up disk space

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Free up disk space
         run: |
           df -h /
-          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/dotnet /usr/local/.ghcup
           df -h /
 
       - name: KVM setup


### PR DESCRIPTION
At the time of this commit, removing the dotnet directory reduced the root
filesystem usage from 57G to 48G.
```
Before:
    Filesystem      Size  Used Avail Use% Mounted on
    /dev/root        73G   57G   16G  79% /
After:
    Filesystem      Size  Used Avail Use% Mounted on
    /dev/root        73G   48G   26G  65% /
```