### PR TITLE
e2e: try to load both kvm modules for Intel and AMD

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,8 +46,8 @@ jobs:
           sudo chmod 777 /var/run/libvirt/libvirt-sock
           sudo ls -la /var/run/libvirt/libvirt-sock
           ls -l /dev/kvm
-          sudo modprobe -a kvm
-          sudo modprobe -a kvm_amd
+          # x86 GitHub Runner can be one of Intel and AMD, so try both.
+          sudo modprobe -a kvm_intel || sudo modprobe -a kvm_amd
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push Docker image with cache


### PR DESCRIPTION
We have been suffered from flaky EPERM error on loading kvm_amd kernel module. It's because GitHub runner can be run on both Intel and AMD machines. To resolve this problem, try to load both kvm modules for intel and AMD.
    
An example when a runner is running on top of Intel mahine:
https://github.com/cybozu-go/fin/actions/runs/18839463075/job/53748050527#step:3:5
```
Run grep -E 'svm|vmx' /proc/cpuinfo
> flags         : <snip> vmx <snip>
```
    
On top of AMD machine:
https://github.com/cybozu-go/fin/actions/runs/18839463075/job/53748139582#step:3:5
```
> flags         : <snip> svm <snip>
``` 
Typically one of both are automatically loaded beforehand by OS. Howerver, it's better to load these modules explicitly.