### PR TITLE
test: migrate to fake RBDRepository2 in job tests

### DIFF
--- a/internal/infrastructure/fake/storage.go
+++ b/internal/infrastructure/fake/storage.go
@@ -1,7 +1,6 @@
 package fake
 
 import (
-	"github.com/cybozu-go/fin/internal/model"
 	"github.com/cybozu-go/fin/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,10 +16,10 @@ type VolumeInfo struct {
 	ImageName string
 }
 
-// NewStorage creates a fake Kubernetes and RBD storage repository.
+// NewStorage creates a fake Kubernetes and VolumeInfo for RBD repository.
 // It creates a PVC, a PV, and a RBD volume with unique names.
 // The PVC is associated with a PV and a corresponding RBD volume.
-func NewStorage() (*fake.Clientset, *RBDRepository, *VolumeInfo) {
+func NewStorage() (*fake.Clientset, *VolumeInfo) {
 	volumeInfo := &VolumeInfo{
 		Namespace: utils.GetUniqueName("ns-"),
 		PVCName:   utils.GetUniqueName("pvc-"),
@@ -58,12 +57,5 @@ func NewStorage() (*fake.Clientset, *RBDRepository, *VolumeInfo) {
 	}
 	k8sClient := fake.NewClientset(pvc, pv)
 
-	// RBD volume without snapshots
-	rbdRepo := &RBDRepository{
-		snapshots: make([]*model.RBDSnapshot, 0),
-		poolName:  volumeInfo.PoolName,
-		imageName: volumeInfo.ImageName,
-	}
-
-	return k8sClient, rbdRepo, volumeInfo
+	return k8sClient, volumeInfo
 }

--- a/internal/job/restore/restore_test.go
+++ b/internal/job/restore/restore_test.go
@@ -57,7 +57,7 @@ type setupOutput struct {
 func setup(t *testing.T, config *setupInput) *setupOutput {
 	t.Helper()
 
-	k8sClient, _, volumeInfo := fake.NewStorage()
+	k8sClient, volumeInfo := fake.NewStorage()
 	rbdRepo := fake.NewRBDRepository2(volumeInfo.PoolName, volumeInfo.ImageName)
 	nlvRepo, finRepo, _ := testutil.CreateNLVAndFinRepoForTest(t)
 

--- a/internal/job/verification/verification_test.go
+++ b/internal/job/verification/verification_test.go
@@ -62,7 +62,7 @@ type setupOutput struct {
 }
 
 func setup(t *testing.T, input *setupInput) *setupOutput {
-	k8sClient, _, volumeInfo := fake.NewStorage()
+	k8sClient, volumeInfo := fake.NewStorage()
 	pvc, err := k8sClient.CoreV1().PersistentVolumeClaims(volumeInfo.Namespace).
 		Get(t.Context(), volumeInfo.PVCName, metav1.GetOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
- Replaced old fake RBDRepository with RBDRepository2 across job tests
- Aligned snapshot sizes to 1024 multiples for divideSize logic