### PR TITLE
job: sync data files before commit

### DIFF
--- a/internal/job/util.go
+++ b/internal/job/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cybozu-go/fin/internal/model"
@@ -64,4 +65,18 @@ func CalcSnapshotNamesWithOffset(
 		targetSnapshotName = fmt.Sprintf("%s-offset-%d", targetSnapshotName, uint64(idx+1)*partSize)
 	}
 	return sourceSnapshotName, targetSnapshotName
+}
+
+func SyncData(filename string) error {
+	f, err := os.OpenFile(filename, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", filename, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("failed to sync %q: %w", filename, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
We should sync data files becore updating backup private data. Otherwise, data corruption happens when system crashes between commit and writeback.