### PR TITLE
pkg: add csumwriter to csumio package for data corruption detection

### DIFF
--- a/internal/pkg/csumio/csumwriter.go
+++ b/internal/pkg/csumio/csumwriter.go
@@ -20,7 +20,7 @@ type Writer struct {
 	buf            []byte
 }
 
-func NewChecksumWriter(dataFile, checksumFile io.Writer, chunkSize int) (*Writer, error) {
+func NewWriter(dataFile, checksumFile io.Writer, chunkSize int) (*Writer, error) {
 	if chunkSize <= MinimumChunkSize && chunkSize%(MinimumChunkSize) != 0 {
 		return nil, fmt.Errorf("chunksize must be at least %d KiB and a multiple of %d KiB when checksum verification is enabled", MinimumChunkSize/1024, MinimumChunkSize/1024)
 	}

--- a/internal/pkg/csumio/csumwriter_test.go
+++ b/internal/pkg/csumio/csumwriter_test.go
@@ -11,17 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChecksumWriter(t *testing.T) {
+func TestWriter_Success(t *testing.T) {
 	// Description:
-	// Check that ChecksumWriter correctly writes data and generates checksums for various data lengths.
+	// Check that Writer correctly writes data and generates checksums for various data lengths.
 	// Tests multiple scenarios: chunk-aligned data and non-aligned data.
 	//
 	// Arrange:
 	// - Prepare test data of various lengths relative to the chunk size
-	// - Create a ChecksumWriter with buffers for data and checksums
+	// - Create a Writer with buffers for data and checksums
 	//
 	// Act:
-	// Write all data using ChecksumWriter, then close
+	// Write all data using Writer, then close
 	//
 	// Assert:
 	// - Data should be written correctly to data buffer
@@ -45,7 +45,7 @@ func TestChecksumWriter(t *testing.T) {
 			// Arrange
 			dataBuffer := &bytes.Buffer{}
 			checksumBuffer := &bytes.Buffer{}
-			cw, err := csumio.NewChecksumWriter(dataBuffer, checksumBuffer, chunkSize)
+			cw, err := csumio.NewWriter(dataBuffer, checksumBuffer, chunkSize)
 			require.NoError(t, err)
 
 			// Act


### PR DESCRIPTION
This PR adds the `csumio` package and introduces `csumwriter`. `csumwriter` writes data along with a checksum file, enabling future implementations (such as a corresponding reader) to verify data integrity and detect corruption.

A simple test is included in `csumwriter_test.go`.  More comprehensive tests and a reader implementation will be added in future pull requests.