### PR TITLE
pkg: add csumreader to csumio package for data corruption detection 

### DIFF
--- a/internal/pkg/csumio/csumreader.go
+++ b/internal/pkg/csumio/csumreader.go
@@ -1,0 +1,73 @@
+package csumio
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+var (
+	ErrChecksumMismatch = errors.New("checksum mismatch")
+)
+
+type Reader struct {
+	dataReader           io.Reader
+	checksumReader       io.Reader
+	buf                  []byte
+	offset               int
+	chunkSize            int
+	enableChecksumVerify bool
+}
+
+func NewReader(dataFile, checksumFile io.Reader, chunkSize int, enableChecksumVerify bool) (*Reader, error) {
+	if enableChecksumVerify {
+		if chunkSize < 4*1024 && chunkSize%(4*1024) != 0 {
+			return nil, fmt.Errorf("chunksize must be at least 4 KiB and a multiple of 4 KiB when checksum verification is enabled")
+		}
+	}
+	return &Reader{
+		dataReader:           dataFile,
+		checksumReader:       checksumFile,
+		chunkSize:            chunkSize,
+		enableChecksumVerify: enableChecksumVerify,
+		buf:                  make([]byte, chunkSize),
+	}, nil
+}
+
+func (cr *Reader) Read(p []byte) (int, error) {
+	if cr.offset == 0 {
+		n, err := io.ReadFull(cr.dataReader, cr.buf)
+		if err == io.ErrUnexpectedEOF {
+			cr.buf = cr.buf[:n]
+		} else if err == io.EOF {
+			return 0, io.EOF
+		} else if err != nil {
+			return 0, fmt.Errorf("failed to read data block: %w", err)
+		}
+
+		if cr.enableChecksumVerify {
+			checksumBytes := make([]byte, ChecksumLen)
+			_, err := io.ReadFull(cr.checksumReader, checksumBytes)
+			if err != nil {
+				return 0, fmt.Errorf("failed to read checksum: %w", err)
+			}
+
+			expected := binary.LittleEndian.Uint64(checksumBytes)
+			actual := xxhash.Sum64(cr.buf)
+			if expected != actual {
+				return 0, fmt.Errorf("%w: expected %016x, got %016x", ErrChecksumMismatch, expected, actual)
+			}
+		}
+		// No checksum reading when verification is disabled
+	}
+
+	n := copy(p, cr.buf[cr.offset:])
+	cr.offset += n
+	if cr.offset >= len(cr.buf) {
+		cr.offset = 0
+	}
+	return n, nil
+}

--- a/internal/pkg/csumio/csumreader_test.go
+++ b/internal/pkg/csumio/csumreader_test.go
@@ -1,0 +1,186 @@
+package csumio_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cybozu-go/fin/internal/pkg/csumio"
+)
+
+func TestReader_ChecksumMismatch_VerificationEnabled(t *testing.T) {
+	// Description:
+	// Check that checksum verification detects checksum mismatch when verification is enabled
+	//
+	// Arrange:
+	// - Data file contains test data
+	// - Checksum file contains checksum for different data (intentionally wrong)
+	// - Checksum verification is enabled
+	//
+	// Act:
+	// Read data using Reader
+	//
+	// Assert:
+	// Should fail with ErrChecksumMismatch
+
+	chunkSize := csumio.MinimumChunkSize
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "exact_chunk", data: bytes.Repeat([]byte("a"), chunkSize)},          // exactly one chunk
+		{name: "partial_chunk", data: bytes.Repeat([]byte("a"), chunkSize-1)},      // less than one chunk
+		{name: "more_than_chunk", data: bytes.Repeat([]byte("a"), chunkSize+1)},    // more than one chunk
+		{name: "two_chunks_aligned", data: bytes.Repeat([]byte("a"), chunkSize*2)}, // exactly two chunks
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			wrongChecksum := uint64(0xdeadbeef) // Intentionally wrong checksum
+			checksumBuf := make([]byte, csumio.ChecksumLen)
+			binary.LittleEndian.PutUint64(checksumBuf, wrongChecksum)
+			dataReader := bytes.NewReader(tc.data)
+			checksumReader := bytes.NewReader(checksumBuf)
+
+			// Act
+			reader, err := csumio.NewReader(dataReader, checksumReader, chunkSize, true)
+			require.NoError(t, err)
+
+			buf := make([]byte, chunkSize)
+			_, err = reader.Read(buf)
+			// Assert
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, csumio.ErrChecksumMismatch)
+		})
+	}
+}
+
+func TestReader_ChecksumMismatch_VerificationDisabled(t *testing.T) {
+	// Description:
+	// Check that checksum verification is ignored when verification is disabled
+	//
+	// Arrange:
+	// - Data file contains test data
+	// - Checksum file contains checksum for different data (intentionally wrong)
+	// - Checksum verification is disabled
+	//
+	// Act:
+	// Read data using Reader
+	//
+	// Assert:
+	// Should succeed and return correct data despite wrong checksum
+
+	chunkSize := csumio.MinimumChunkSize
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "exact_chunk", data: bytes.Repeat([]byte("a"), chunkSize)},          // exactly one chunk
+		{name: "partial_chunk", data: bytes.Repeat([]byte("a"), chunkSize-1)},      // less than one chunk
+		{name: "more_than_chunk", data: bytes.Repeat([]byte("a"), chunkSize+1)},    // more than one chunk
+		{name: "two_chunks_aligned", data: bytes.Repeat([]byte("a"), chunkSize*2)}, // exactly two chunks
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			wrongChecksum := uint64(0xdeadbeef) // Intentionally wrong checksum
+			checksumBuf := make([]byte, csumio.ChecksumLen)
+			binary.LittleEndian.PutUint64(checksumBuf, wrongChecksum)
+			dataReader := bytes.NewReader(tc.data)
+			checksumReader := bytes.NewReader(checksumBuf)
+
+			// Act
+			reader, err := csumio.NewReader(dataReader, checksumReader, chunkSize, false)
+			require.NoError(t, err)
+
+			buf := make([]byte, len(tc.data))
+			_, err = io.ReadFull(reader, buf)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, tc.data, buf)
+		})
+	}
+}
+
+func TestReader_CorrectChecksum_VerificationEnabled(t *testing.T) {
+	// Description:
+	// Check that checksum verification succeeds when checksums match and verification is enabled.
+	// Tests multiple scenarios: exact chunk, partial chunk, and multiple chunks.
+	//
+	// Arrange:
+	// - Data file contains test data of various lengths relative to chunk size
+	// - Checksum file contains correct checksums for all chunks in the data
+	// - Checksum verification is enabled
+	//
+	// Act:
+	// Read all data using Reader sequentially, then attempt one more read
+	//
+	// Assert:
+	// - All chunk reads should succeed and return correct data
+	// - Final read should return EOF
+
+	chunkSize := csumio.MinimumChunkSize
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "exact_chunk", data: bytes.Repeat([]byte("a"), chunkSize)},          // exactly one chunk
+		{name: "partial_chunk", data: bytes.Repeat([]byte("a"), chunkSize-1)},      // less than one chunk
+		{name: "more_than_chunk", data: bytes.Repeat([]byte("a"), chunkSize+1)},    // more than one chunk
+		{name: "two_chunks_aligned", data: bytes.Repeat([]byte("a"), chunkSize*2)}, // exactly two chunks
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			numChunks := (len(tc.data) + chunkSize - 1) / chunkSize
+			checksumBytes := make([]byte, 0, numChunks*csumio.ChecksumLen)
+			for i := 0; i < numChunks; i++ {
+				start := i * chunkSize
+				end := start + chunkSize
+				if end > len(tc.data) {
+					end = len(tc.data)
+				}
+				cs := xxhash.Sum64(tc.data[start:end])
+				b := make([]byte, csumio.ChecksumLen)
+				binary.LittleEndian.PutUint64(b, cs)
+				checksumBytes = append(checksumBytes, b...)
+			}
+
+			dataReader := bytes.NewReader(tc.data)
+			checksumReader := bytes.NewReader(checksumBytes)
+
+			reader, err := csumio.NewReader(dataReader, checksumReader, chunkSize, true)
+			require.NoError(t, err)
+			buf := make([]byte, chunkSize)
+
+			for i := 0; i < numChunks; i++ {
+				// Act
+				n, err := reader.Read(buf)
+
+				// Assert
+				assert.NoError(t, err)
+				expectedLen := chunkSize
+				if (i+1)*chunkSize > len(tc.data) {
+					expectedLen = len(tc.data) - i*chunkSize
+				}
+
+				start := i * chunkSize
+				assert.Equal(t, expectedLen, n)
+				assert.Equal(t, tc.data[start:start+expectedLen], buf[:n])
+			}
+
+			n, err := reader.Read(buf)
+			assert.Equal(t, 0, n)
+			assert.Equal(t, io.EOF, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces `csumreader`, which reads data files along with their corresponding checksum files to verify data integrity and detect corruption. 

A simple test is included in `csumreader_test.go`, and more comprehensive tests will be added in future pull requests.