### PR TITLE
e2e: keep matrix jobs running on failure

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,7 @@ jobs:
   build:
     runs-on: "ubuntu-22.04"
     strategy:
+      fail-fast: false
       matrix:
         label-filter:
           - full-backup


### PR DESCRIPTION
Add `fail-fast: false` to e2e.yaml. This prevents canceling remaining matrix jobs when one job fails, allowing collection of results from all e2e labels (full-backup, incremental-backup, misc).