### PR TITLE
feat: integrate csumio in job layer 

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -126,6 +126,7 @@ func backupJobMain() error {
 		TargetPVCUID:              pvcUID,
 		MaxPartSize:               maxPartSize,
 		ExpansionUnitSize:         expansionUnitSize,
+		DiffChecksumChunkSize:     defaultDiffChecksumChunkSize, // this could be configurable in the future
 	})
 	for {
 		err = b.Perform()

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -84,14 +84,15 @@ func restoreJobMain() error {
 	}
 
 	r := restore.NewRestore(&input.Restore{
-		Repo:                finRepo,
-		RBDRepo:             rbdRepo,
-		NodeLocalVolumeRepo: nlvRepo,
-		ActionUID:           actionUID,
-		TargetSnapshotID:    targetSnapshotID,
-		TargetPVCUID:        pvcUID,
-		RawImageChunkSize:   rawImageChunkSize,
-		RestoreVol:          restoreVol,
+		Repo:                  finRepo,
+		RBDRepo:               rbdRepo,
+		NodeLocalVolumeRepo:   nlvRepo,
+		ActionUID:             actionUID,
+		TargetSnapshotID:      targetSnapshotID,
+		TargetPVCUID:          pvcUID,
+		RawImageChunkSize:     rawImageChunkSize,
+		DiffChecksumChunkSize: defaultDiffChecksumChunkSize,
+		RestoreVol:            restoreVol,
 	})
 
 	for {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const defaultDiffChecksumChunkSize = 2 * 1024 * 1024 // 2 MiB
+
 func getClientSet() (*kubernetes.Clientset, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/internal/infrastructure/ceph/rbd_test.go
+++ b/internal/infrastructure/ceph/rbd_test.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const diffChecksumChunkSize = 2 * 1024 * 1024
+
 func TestReadDiffHeaderAndMetadata_full_success(t *testing.T) {
 	header, err := readDiffHeaderAndMetadata(bufio.NewReader(openGZFile(t, "testdata/full.gz")))
 	assert.NoError(t, err)
@@ -1098,6 +1100,7 @@ func TestApplyDiffToBlockDevice_error_MissingDiffFileName(t *testing.T) {
 		"non existing file",
 		"fromSnap",
 		"toSnap",
+		diffChecksumChunkSize,
 	)
 
 	// Assert

--- a/internal/infrastructure/nlv/nlv.go
+++ b/internal/infrastructure/nlv/nlv.go
@@ -21,6 +21,7 @@ const (
 	imageFilePath              = "raw.img"
 	instantVerifyImageFilePath = "instant_verify.img"
 	VolumePath                 = "/volume"
+	checksumSuffix             = ".csum"
 )
 
 type NodeLocalVolumeRepository struct {
@@ -63,8 +64,16 @@ func (r *NodeLocalVolumeRepository) GetDiffPartPath(snapshotID, partIndex int) s
 	return filepath.Join(r.root.Name(), getDiffRelPath(snapshotID), fmt.Sprintf("part-%d", partIndex))
 }
 
+func (r *NodeLocalVolumeRepository) GetDiffChecksumPath(snapshotID, partIndex int) string {
+	return ChecksumFilePath(r.GetDiffPartPath(snapshotID, partIndex))
+}
+
 func (r *NodeLocalVolumeRepository) GetRawImagePath() string {
 	return filepath.Join(r.root.Name(), imageFilePath)
+}
+
+func (r *NodeLocalVolumeRepository) GetRawImageChecksumPath() string {
+	return ChecksumFilePath(r.GetRawImagePath())
 }
 
 func (r *NodeLocalVolumeRepository) GetInstantVerifyImagePath() string {
@@ -250,4 +259,7 @@ func (r *NodeLocalVolumeRepository) ReflinkRawImageToInstantVerifyImage() error 
 		return fmt.Errorf("failed to reflink: %w: %s", err, output)
 	}
 	return nil
+}
+func ChecksumFilePath(path string) string {
+	return path + checksumSuffix
 }

--- a/internal/infrastructure/restore/restore_test.go
+++ b/internal/infrastructure/restore/restore_test.go
@@ -1,0 +1,143 @@
+package restore_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cybozu-go/fin/internal/infrastructure/nlv"
+	"github.com/cybozu-go/fin/internal/infrastructure/restore"
+	"github.com/cybozu-go/fin/internal/pkg/csumio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	rawImageFileName     = "raw.img"
+	restoreImageFileName = "restore.img"
+	chunkSize            = csumio.MinimumChunkSize
+)
+
+func writeRawWithChecksum(t *testing.T, rawPath string, data []byte) {
+	t.Helper()
+
+	rawFile, err := os.Create(rawPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rawFile.Close()) }()
+	checksumFile, err := os.Create(nlv.ChecksumFilePath(rawPath))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, checksumFile.Close()) }()
+
+	writer, err := csumio.NewWriter(rawFile, checksumFile, chunkSize)
+	require.NoError(t, err)
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+}
+
+func prepareRestoreVolume(t *testing.T, path string, size int64) *restore.RestoreVolume {
+	t.Helper()
+
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, file.Truncate(size))
+	require.NoError(t, file.Close())
+
+	return restore.NewRestoreVolume(path)
+}
+
+func TestCopyChunk(t *testing.T) {
+	// Description:
+	// This test verifies CopyChunk behavior under combinations
+	// of checksum verification enabled/disabled and checksum file integrity.
+	//
+	// Arrange:
+	// For each scenario, prepare a temporary raw image filled with constant data
+	// and optionally corrupt the associated checksum entries.
+	//
+	// Act:
+	// Invoke CopyChunk with the configured checksum verification flag.
+	//
+	// Assert:
+	// - When checksum verification is enabled and checksums match, data is copied.
+	// - When verification is enabled and checksums are corrupted, CopyChunk returns ErrChecksumMismatch.
+	// - When verification is disabled, data is copied regardless of checksum corruption.
+	const (
+		writtenDataByte       byte = 0xAA
+		corruptedChecksumByte byte = 0x01
+	)
+
+	testCases := []struct {
+		name          string
+		enableVerify  bool
+		matchChecksum bool
+		expectErr     error
+	}{
+		{
+			name:          "ChecksumMatch_EnableVerify",
+			enableVerify:  true,
+			matchChecksum: true,
+		},
+		{
+			name:          "ChecksumMismatch_EnableVerify",
+			enableVerify:  true,
+			matchChecksum: false,
+			expectErr:     csumio.ErrChecksumMismatch,
+		},
+		{
+			name:          "ChecksumMismatch_DisableVerify",
+			enableVerify:  false,
+			matchChecksum: false,
+		},
+		{
+			name:          "ChecksumMatch_DisableVerify",
+			enableVerify:  false,
+			matchChecksum: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			data := bytes.Repeat([]byte{writtenDataByte}, chunkSize)
+			tmpDir := t.TempDir()
+			rawPath := filepath.Join(tmpDir, rawImageFileName)
+			writeRawWithChecksum(t, rawPath, data)
+
+			if !tc.matchChecksum {
+				err := os.WriteFile(
+					nlv.ChecksumFilePath(rawPath),
+					bytes.Repeat([]byte{corruptedChecksumByte}, csumio.ChecksumLen),
+					0644,
+				)
+				require.NoError(t, err)
+			}
+
+			restorePath := filepath.Join(tmpDir, restoreImageFileName)
+			rv := prepareRestoreVolume(t, restorePath, int64(chunkSize))
+
+			// Act
+			err := rv.CopyChunk(rawPath, 0, uint64(chunkSize), tc.enableVerify)
+
+			// Assert
+			if tc.expectErr != nil {
+				assert.ErrorIs(t, err, tc.expectErr)
+				return
+			}
+
+			restoreFile, err := os.Open(restorePath)
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, restoreFile.Close())
+			}()
+
+			readBuf := make([]byte, chunkSize)
+			_, err = io.ReadFull(restoreFile, readBuf)
+			assert.NoError(t, err)
+			assert.Equal(t, data, readBuf)
+		})
+	}
+}

--- a/internal/job/input/backup.go
+++ b/internal/job/input/backup.go
@@ -20,4 +20,5 @@ type Backup struct {
 	TargetPVCUID              string
 	MaxPartSize               uint64
 	ExpansionUnitSize         uint64
+	DiffChecksumChunkSize     uint64
 }

--- a/internal/job/input/restore.go
+++ b/internal/job/input/restore.go
@@ -5,12 +5,13 @@ import (
 )
 
 type Restore struct {
-	Repo                model.FinRepository
-	RBDRepo             model.RBDRepository
-	NodeLocalVolumeRepo model.NodeLocalVolumeRepository
-	RestoreVol          model.RestoreVolume
-	ActionUID           string
-	TargetSnapshotID    int
-	RawImageChunkSize   uint64
-	TargetPVCUID        string
+	Repo                  model.FinRepository
+	RBDRepo               model.RBDRepository
+	NodeLocalVolumeRepo   model.NodeLocalVolumeRepository
+	RestoreVol            model.RestoreVolume
+	ActionUID             string
+	TargetSnapshotID      int
+	RawImageChunkSize     uint64
+	DiffChecksumChunkSize uint64
+	TargetPVCUID          string
 }

--- a/internal/job/restore/restore_test.go
+++ b/internal/job/restore/restore_test.go
@@ -274,8 +274,9 @@ func TestRestore_ErrorBusy(t *testing.T) {
 	// Act:
 	//    Try to run the restore process.
 	restore := NewRestore(&input.Restore{
-		Repo:      finRepo,
-		ActionUID: actionUID,
+		Repo:                  finRepo,
+		ActionUID:             actionUID,
+		DiffChecksumChunkSize: testutil.DiffChecksumChunkSize,
 	})
 	err = restore.Perform()
 

--- a/internal/job/testutil/testutil.go
+++ b/internal/job/testutil/testutil.go
@@ -24,7 +24,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const SnapshotTimeFormat = "Mon Jan  2 15:04:05 2006"
+const (
+	SnapshotTimeFormat    = "Mon Jan  2 15:04:05 2006"
+	DiffChecksumChunkSize = 2 * 1024 * 1024 // 2 MiB
+)
 
 // NewBackupInput creates a BackupInput for testing using a fake clientSet and a fake.VolumeInfo.
 func NewBackupInput(
@@ -54,6 +57,7 @@ func NewBackupInput(
 		TargetPVCUID:              string(pvc.UID),
 		MaxPartSize:               maxPartSize,
 		ExpansionUnitSize:         utils.RawImgExpansionUnitSize,
+		DiffChecksumChunkSize:     DiffChecksumChunkSize,
 	}
 }
 
@@ -62,13 +66,14 @@ func NewRestoreInputTemplate(bi *input.Backup,
 	return &input.Restore{
 		Repo: bi.Repo,
 		// Restore module uses only ApplyDiffToBlockDevice, so fake is not needed here.
-		RBDRepo:             ceph.NewRBDRepository(),
-		NodeLocalVolumeRepo: bi.NodeLocalVolumeRepo,
-		RestoreVol:          rVol,
-		RawImageChunkSize:   chunkSize,
-		TargetSnapshotID:    snapID,
-		ActionUID:           bi.ActionUID,
-		TargetPVCUID:        bi.TargetPVCUID,
+		RBDRepo:               ceph.NewRBDRepository(),
+		NodeLocalVolumeRepo:   bi.NodeLocalVolumeRepo,
+		RestoreVol:            rVol,
+		RawImageChunkSize:     chunkSize,
+		TargetSnapshotID:      snapID,
+		ActionUID:             bi.ActionUID,
+		TargetPVCUID:          bi.TargetPVCUID,
+		DiffChecksumChunkSize: DiffChecksumChunkSize,
 	}
 }
 

--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"time"
 
@@ -84,7 +85,6 @@ type ExportDiffInput struct {
 	MidSnapPrefix  string
 	ImageName      string
 	TargetSnapName string
-	OutputFile     string
 }
 
 type RBDSnapshotCreateRepository interface {
@@ -114,10 +114,10 @@ type RBDRepository interface {
 
 	// ExportDiff exports the difference between the source snapshot and the target snapshot.
 	// If the source snapshot is not specified, it exports the difference from the empty image.
-	ExportDiff(input *ExportDiffInput) error
+	ExportDiff(input *ExportDiffInput) (io.ReadCloser, error)
 
 	// ApplyDiffToBlockDevice applies the difference from the diff file to the block device.
-	ApplyDiffToBlockDevice(blockDevicePath, diffFilePath, fromSnapName, toSnapName string) error
+	ApplyDiffToBlockDevice(blockDevicePath, diffFilePath, fromSnapName, toSnapName string, diffChecksumChunkSize uint64) error
 
 	// ApplyDiffToRawImage applies the difference from the diff file to the raw image file.
 	ApplyDiffToRawImage(rawImageFilePath, diffFilePath, fromSnapName, toSnapName string, expansionUnitSize uint64) error
@@ -129,8 +129,14 @@ type NodeLocalVolumeRepository interface {
 	// GetDiffPartPath returns the diff part path.
 	GetDiffPartPath(snapshotID, partIndex int) string
 
+	// GetDiffChecksumPath returns the checksum path for a diff part.
+	GetDiffChecksumPath(snapshotID, partIndex int) string
+
 	// GetRawImagePath returns the path of raw.img
 	GetRawImagePath() string
+
+	// GetRawImageChecksumPath returns the checksum path for raw.img
+	GetRawImageChecksumPath() string
 
 	// GetInstantVerifyImagePath returns the path of instant_verify.img
 	GetInstantVerifyImagePath() string

--- a/internal/model/volume.go
+++ b/internal/model/volume.go
@@ -9,5 +9,5 @@ type RestoreVolume interface {
 	ZeroOut() error
 
 	// CopyChunk copy a chunk from raw.img to the restore volume
-	CopyChunk(rawPath string, index int, chunkSize uint64) error
+	CopyChunk(rawPath string, index int, chunkSize uint64, enableChecksumVerify bool) error
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 func main() {
 	if err := cmd.Execute(); err != nil {
 		slog.Error("failed to execute command", "error", err)
+		// TODO: when controller logic is updated, use exit code 3 for fsck failures and exit code 2 for csumio-detected checksum mismatches.
 		if errors.Is(err, verification.ErrFsckFailed) {
 			os.Exit(2)
 		}


### PR DESCRIPTION
In this pull request, csumio is integrated into the Job. Please refer to the commit messages for detailed changes. However, the following updates are not included in this PR:

- Changes related to applyDiffToRawImage. For example, the logic for calling applyDiffToRawImage from the backup job, delete job, or verify job, as well as the preparatory steps required for that, are not added here.
- Adding backup metadata to fin.sqlite3 and having each job read rawChecksumChunkSize and diffChecksumChunkSize to use with csumio. These will be implemented in follow-up PRs.