### PR TITLE
feat: add finbackupconfigInfo metric

### DIFF
--- a/internal/controller/finbackupconfig_controller.go
+++ b/internal/controller/finbackupconfig_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	finv1 "github.com/cybozu-go/fin/api/v1"
+	"github.com/cybozu-go/fin/internal/pkg/metrics"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -80,6 +81,7 @@ func (r *FinBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.Info("the target pvc is not managed by this controller")
 		return ctrl.Result{}, nil
 	}
+	metrics.SetFinBackupConfigInfo(&fbc, r.managedCephClusterID)
 
 	image := r.podImage
 

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -26,6 +26,15 @@ const (
 )
 
 var (
+	finbackupconfigInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Name:      "finbackupconfig_info",
+			Help:      "Information about FinBackupConfig",
+		},
+		[]string{cephNSLabel, pvcLabel, pvcNSLabel, nsLabel, fbcLabel, nodeLabel},
+	)
+
 	backupDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricNamespace,
@@ -47,6 +56,13 @@ var (
 
 	registerOnce sync.Once
 )
+
+func SetFinBackupConfigInfo(fbc *finv1.FinBackupConfig, cephNamespace string) {
+	if fbc == nil {
+		return
+	}
+	finbackupconfigInfo.WithLabelValues(cephNamespace, fbc.Spec.PVC, fbc.Spec.PVCNamespace, fbc.Namespace, fbc.Name, fbc.Spec.Node).Set(1)
+}
 
 func SetBackupDurationSeconds(fb *finv1.FinBackup, untilCondition, cephNamespace string, fullBackup bool) {
 	if fb == nil {
@@ -80,6 +96,7 @@ func SetBackupCreateStatus(fb *finv1.FinBackup, cephNamespace string, inProgress
 func Register() {
 	registerOnce.Do(func() {
 		metrics.Registry.MustRegister(
+			finbackupconfigInfo,
 			backupCreateStatus,
 			backupDurationSeconds,
 		)


### PR DESCRIPTION
Not implemented the deletion logic for `_info` metric
because there is no reconciler for FinBackupConfig deletion.