### PR TITLE
feat: add checksum verification to applyDiffToRawImage

### DIFF
--- a/internal/infrastructure/ceph/rbd.go
+++ b/internal/infrastructure/ceph/rbd.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/cybozu-go/fin/internal/infrastructure/nlv"
 	"github.com/cybozu-go/fin/internal/model"
 	"github.com/cybozu-go/fin/internal/pkg/csumio"
@@ -25,7 +26,18 @@ import (
 
 var (
 	DefaultExpansionUnitSize uint64 = 100 * 1024 * 1024 * 1024 // 100 GiB
+	ErrChecksumMismatch             = errors.New("checksum mismatch")
+	csumZero                 uint64
 )
+
+const (
+	defaultRawChecksumChunkSize  uint64 = 64 * 1024       // 64 KiB
+	defaultDiffChecksumChunkSize uint64 = 2 * 1024 * 1024 // 2MiB
+)
+
+func init() {
+	csumZero = calcZeroChecksum(defaultRawChecksumChunkSize)
+}
 
 type RBDRepository struct {
 }
@@ -151,13 +163,42 @@ func (r *RBDRepository) ApplyDiffToBlockDevice(blockDevicePath, diffFilePath, fr
 func (r *RBDRepository) ApplyDiffToRawImage(
 	rawImageFilePath, diffFilePath, fromSnapName, toSnapName string, expansionUnitSize uint64,
 ) error {
-	diffFile, err := os.Open(diffFilePath)
+	// TODO: These parameters will be configurable via arguments in PR #187.
+	rawChecksumChunkSize := defaultRawChecksumChunkSize
+	diffChecksumChunkSize := defaultDiffChecksumChunkSize
+	enableChecksumVerify := false
+
+	f, err := os.Open(diffFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to open diff file: %s: %w", diffFilePath, err)
 	}
-	defer func() { _ = diffFile.Close() }()
+	defer func() { _ = f.Close() }()
 
-	return applyDiffToRawImage(rawImageFilePath, diffFile, fromSnapName, toSnapName, expansionUnitSize)
+	var cf *os.File
+	var diffFile io.Reader = f
+	if enableChecksumVerify {
+		checksumFilePath := getChecksumFilePath(diffFilePath)
+		cf, err = os.Open(checksumFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to open checksum file: %s: %w", checksumFilePath, err)
+		}
+		defer func() { _ = cf.Close() }()
+	}
+
+	diffFile, err = csumio.NewReader(diffFile, cf, int(diffChecksumChunkSize), enableChecksumVerify)
+	if err != nil {
+		return fmt.Errorf("failed to create csumreader: %w", err)
+	}
+
+	return applyDiffToRawImage(
+		rawImageFilePath,
+		diffFile,
+		fromSnapName,
+		toSnapName,
+		expansionUnitSize,
+		rawChecksumChunkSize,
+		enableChecksumVerify,
+	)
 }
 
 func applyDiffToBlockDevice(blockDevicePath string, diffFile io.Reader, fromSnapName, toSnapName string) error {
@@ -181,47 +222,131 @@ func applyDiffToBlockDevice(blockDevicePath string, diffFile io.Reader, fromSnap
 		return fmt.Errorf("block device size is smaller than diff size: %s", blockDevicePath)
 	}
 
-	if err = applyDiffDataRecords(blockDeviceFile, diffFileReader, 0, true); err != nil {
+	if err = applyDiffDataRecords(blockDeviceFile, diffFileReader, 0, true, false, 0, nil); err != nil {
 		return fmt.Errorf("failed to apply diff records to %s: %w", blockDevicePath, err)
 	}
 
 	return nil
 }
 
+//nolint:unparam // parameters are currently constant; remove once they become configurable.
 func applyDiffToRawImage(
 	rawImageFilePath string,
 	diffFile io.Reader,
 	fromSnapName,
 	toSnapName string,
-	expansionUnitSize uint64,
+	expansionUnitSize,
+	rawChecksumChunkSize uint64,
+	enableChecksumVerify bool,
 ) error {
 	diffFileReader, _, err := openDiffDataRecords(diffFile, fromSnapName, toSnapName)
 	if err != nil {
 		return fmt.Errorf("failed to open diff data records: %w", err)
 	}
 
-	// Open raw image file
 	var rawImgFile *os.File
-	if _, err := os.Stat(rawImageFilePath); os.IsNotExist(err) {
-		rawImgFile, err = os.OpenFile(rawImageFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	var rawChecksumFile *os.File
+
+	rawStat, err := os.Stat(rawImageFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat raw image file: %w", err)
+	}
+
+	// When raw.img already exists check the chunk counts of raw.img and its checksum file.
+	// A smaller raw chunk count means the checksum was created before raw.img was written at all,
+	// or the process stopped while raw.img was being written. The next retry recreates both.
+	//
+	// This check also covers cases where applyDiffDataRecords extended the checksum file but raw.img
+	// was not extended due to disruption.
+	rawNotExist := os.IsNotExist(err)
+	rawCreationIncomplete := false
+	if enableChecksumVerify && !rawNotExist {
+		checksumFilePath := getChecksumFilePath(rawImageFilePath)
+		checksumStat, err := os.Stat(checksumFilePath)
+		if os.IsNotExist(err) {
+			return ErrChecksumMismatch
+		} else if err != nil {
+			return fmt.Errorf("failed to stat checksum file %s: %w", checksumFilePath, err)
+		}
+		rawChunks := (uint64(rawStat.Size()) + rawChecksumChunkSize - 1) / rawChecksumChunkSize
+		checksumChunks := uint64(checksumStat.Size()) / csumio.ChecksumLen
+		if rawChunks < checksumChunks {
+			rawCreationIncomplete = true
+		}
+	}
+
+	if rawNotExist || rawCreationIncomplete {
+		// Note: The checksum file must be updated first. If it is not updated before writing raw.img,
+		// and a crash occurs while updating the checksum, the next retry will fail checksum verification.
+		// By updating the checksum first, we ensure that if a crash occurs, the file can be safely
+		// recreated on the next attempt.
+		if enableChecksumVerify {
+			checksumFilePath := getChecksumFilePath(rawImageFilePath)
+			rawChecksumFile, err = os.OpenFile(checksumFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+			if err != nil {
+				return fmt.Errorf("failed to create checksum file: %s: %w", checksumFilePath, err)
+			}
+			defer func() { _ = rawChecksumFile.Close() }()
+
+			numChunks := expansionUnitSize / rawChecksumChunkSize
+			if expansionUnitSize%rawChecksumChunkSize != 0 {
+				numChunks++
+			}
+			for i := uint64(0); i < numChunks; i++ {
+				if err := writeChecksumAtChunk(rawChecksumFile, i, csumZero); err != nil {
+					return fmt.Errorf("failed to initialize checksum file: %w", err)
+				}
+			}
+			if err := rawChecksumFile.Sync(); err != nil {
+				return fmt.Errorf("failed to sync checksum file: %w", err)
+			}
+		}
+		flag := os.O_CREATE | os.O_TRUNC
+		if enableChecksumVerify {
+			flag |= os.O_RDWR
+		} else {
+			flag |= os.O_WRONLY
+		}
+		rawImgFile, err = os.OpenFile(rawImageFilePath, flag, 0644)
 		if err != nil {
 			return fmt.Errorf("failed to open file: %s: %w", rawImageFilePath, err)
 		}
 		defer func() { _ = rawImgFile.Close() }()
+
 		if err := unix.Fallocate(int(rawImgFile.Fd()), 0, 0, int64(expansionUnitSize)); err != nil {
 			return fmt.Errorf("failed to fallocate: %s: %w", rawImageFilePath, err)
 		}
-	} else if err != nil {
-		return fmt.Errorf("failed to stat raw image file: %w", err)
+		if err := rawImgFile.Sync(); err != nil {
+			return fmt.Errorf("failed to sync %s: %w", rawImageFilePath, err)
+		}
 	} else {
-		rawImgFile, err = os.OpenFile(rawImageFilePath, os.O_WRONLY, 0644)
+		rawImgFile, err = os.OpenFile(rawImageFilePath, os.O_RDWR, 0644)
 		if err != nil {
 			return fmt.Errorf("failed to open file: %s: %w", rawImageFilePath, err)
 		}
 		defer func() { _ = rawImgFile.Close() }()
+
+		// Open checksum file if verification is enabled
+		if enableChecksumVerify {
+			checksumFilePath := getChecksumFilePath(rawImageFilePath)
+			rawChecksumFile, err = os.OpenFile(checksumFilePath, os.O_RDWR, 0644)
+			if err != nil {
+				return fmt.Errorf("failed to open checksum file %s: %w", checksumFilePath, err)
+			}
+			defer func() { _ = rawChecksumFile.Close() }()
+		}
 	}
 
-	if err := applyDiffDataRecords(rawImgFile, diffFileReader, expansionUnitSize, false); err != nil {
+	err = applyDiffDataRecords(
+		rawImgFile,
+		diffFileReader,
+		expansionUnitSize,
+		false,
+		enableChecksumVerify,
+		rawChecksumChunkSize,
+		rawChecksumFile,
+	)
+	if err != nil {
 		return fmt.Errorf("failed to apply diff records to %q: %w", rawImageFilePath, err)
 	}
 
@@ -232,6 +357,9 @@ func openDiffDataRecords(diffFile io.Reader, fromSnapName, toSnapName string) (*
 	diffFileReader := bufio.NewReader(diffFile)
 	diffHeader, err := readDiffHeaderAndMetadata(diffFileReader)
 	if err != nil {
+		if errors.Is(err, csumio.ErrChecksumMismatch) {
+			err = errors.Join(err, ErrChecksumMismatch)
+		}
 		return nil, nil, fmt.Errorf("failed to read diff header: %w", err)
 	}
 	if diffHeader.FromSnapName != fromSnapName || diffHeader.ToSnapName != toSnapName {
@@ -242,12 +370,27 @@ func openDiffDataRecords(diffFile io.Reader, fromSnapName, toSnapName string) (*
 	return diffFileReader, diffHeader, nil
 }
 
+//nolint:gocyclo
 func applyDiffDataRecords(
 	dstFile *os.File,
 	diffFileReader *bufio.Reader,
 	expansionUnitSize uint64,
 	isDstBlockDevice bool,
+	enableChecksumVerification bool,
+	rawChecksumChunkSize uint64,
+	rawChecksumFile *os.File,
 ) error {
+	if enableChecksumVerification {
+		if isDstBlockDevice {
+			return fmt.Errorf("checksum verification is not supported for block devices")
+		}
+		if rawChecksumChunkSize == 0 {
+			return fmt.Errorf("raw checksum chunk size must be > 0 when checksum verification is enabled")
+		}
+		if rawChecksumFile == nil {
+			return fmt.Errorf("checksum file must be provided when checksum verification is enabled")
+		}
+	}
 	stat, err := dstFile.Stat()
 	if err != nil {
 		return fmt.Errorf("failed to stat destination file: %w", err)
@@ -255,9 +398,13 @@ func applyDiffDataRecords(
 	fileSize := stat.Size()
 	prevOffset := uint64(0)
 	prevLength := uint64(0)
+
 	for {
 		tag, err := diffFileReader.ReadByte()
 		if err != nil {
+			if errors.Is(err, csumio.ErrChecksumMismatch) {
+				return fmt.Errorf("failed to read tag byte: %w: %w", ErrChecksumMismatch, err)
+			}
 			return fmt.Errorf("failed to read tag byte: %w", err)
 		}
 		switch tag {
@@ -281,10 +428,79 @@ func applyDiffDataRecords(
 
 			// Expand raw image file if necessary
 			if !isDstBlockDevice && offset+length > uint64(fileSize) {
-				fileSize = int64(math.Ceil(float64(offset+length)/float64(expansionUnitSize)) * float64(expansionUnitSize))
+				targetFileSize := int64(math.Ceil(float64(offset+length)/float64(expansionUnitSize)) * float64(expansionUnitSize))
+
+				if enableChecksumVerification {
+					info, err := rawChecksumFile.Stat()
+					if err != nil {
+						return fmt.Errorf("failed to stat checksum file: %w", err)
+					}
+					currentChunks := uint64(info.Size()) / csumio.ChecksumLen
+					neededChunks := uint64(targetFileSize) / rawChecksumChunkSize
+					if uint64(targetFileSize)%rawChecksumChunkSize != 0 {
+						neededChunks++
+					}
+					for currentChunks < neededChunks {
+						if err := writeChecksumAtChunk(rawChecksumFile, currentChunks, csumZero); err != nil {
+							return fmt.Errorf("failed to extend checksum file: %w", err)
+						}
+						currentChunks++
+					}
+					if err := rawChecksumFile.Sync(); err != nil {
+						return fmt.Errorf("failed to sync checksum file: %w", err)
+					}
+				}
+				fileSize = targetFileSize
 				if err := unix.Fallocate(int(dstFile.Fd()), 0, 0, fileSize); err != nil {
 					return fmt.Errorf("failed to fallocate raw image file: %w", err)
 				}
+			}
+
+			if enableChecksumVerification {
+				if length == 0 {
+					continue
+				}
+
+				startChunkIndex := offset / rawChecksumChunkSize
+				endChunkIndex := (offset + length - 1) / rawChecksumChunkSize
+
+				for chunkIndex := startChunkIndex; chunkIndex <= endChunkIndex; chunkIndex++ {
+					chunkStartPos := chunkIndex * rawChecksumChunkSize
+					chunkEndPos := chunkStartPos + rawChecksumChunkSize
+					writeStartPos := max(offset, chunkStartPos)
+					writeEndPos := min(offset+length, chunkEndPos)
+					writeSize := writeEndPos - writeStartPos
+
+					if writeSize == rawChecksumChunkSize {
+						if err := processEntireChunkWrite(
+							dstFile,
+							rawChecksumFile,
+							diffFileReader,
+							tag,
+							chunkIndex,
+							chunkStartPos,
+							rawChecksumChunkSize,
+						); err != nil {
+							return err
+						}
+					} else {
+						if err := processPartialChunkWrite(
+							dstFile,
+							rawChecksumFile,
+							diffFileReader,
+							tag,
+							chunkIndex,
+							chunkStartPos,
+							writeStartPos,
+							writeSize,
+							rawChecksumChunkSize,
+						); err != nil {
+							return err
+						}
+					}
+				}
+
+				continue
 			}
 
 			// Write data to destination file
@@ -318,6 +534,171 @@ func applyDiffDataRecords(
 			return fmt.Errorf("unexpected tag: %c", tag)
 		}
 	}
+}
+
+func processEntireChunkWrite(
+	dstFile *os.File,
+	dstChecksumFile *os.File,
+	diffFileReader *bufio.Reader,
+	tag byte,
+	chunkIndex uint64,
+	chunkStartPos uint64,
+	rawChecksumChunkSize uint64,
+) error {
+	if tag == 'w' { // UPDATED DATA
+		chunkData := make([]byte, rawChecksumChunkSize)
+		_, err := io.ReadFull(diffFileReader, chunkData)
+		if err != nil {
+			if errors.Is(err, csumio.ErrChecksumMismatch) {
+				return fmt.Errorf("failed to read chunk data: %w: %w", ErrChecksumMismatch, err)
+			}
+			return fmt.Errorf("failed to read chunk data: %w", err)
+		}
+
+		csumUpdated := xxhash.Sum64(chunkData)
+
+		// Update checksum file
+		if err := writeChecksumAtChunk(dstChecksumFile, chunkIndex, csumUpdated); err != nil {
+			return err
+		}
+
+		// Update raw.img
+		if _, err := dstFile.Seek(int64(chunkStartPos), io.SeekStart); err != nil {
+			return fmt.Errorf("failed to seek in destination file: %w", err)
+		}
+		if _, err := dstFile.Write(chunkData); err != nil {
+			return fmt.Errorf("failed to write to destination file: %w", err)
+		}
+	} else { // ZERO DATA
+		// Update checksum file
+		if err := writeChecksumAtChunk(dstChecksumFile, chunkIndex, csumZero); err != nil {
+			return err
+		}
+
+		// Write zeros using fallocate
+		if err := unix.Fallocate(
+			int(dstFile.Fd()),
+			unix.FALLOC_FL_KEEP_SIZE|unix.FALLOC_FL_PUNCH_HOLE,
+			int64(chunkStartPos),
+			int64(rawChecksumChunkSize),
+		); err != nil {
+			return fmt.Errorf("failed to write zero data: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func processPartialChunkWrite(
+	rawFile *os.File,
+	rawChecksumFile *os.File,
+	diffFileReader *bufio.Reader,
+	tag byte,
+	chunkIndex uint64,
+	chunkStartPos uint64,
+	writeStartPos uint64,
+	writeSize uint64,
+	rawChecksumChunkSize uint64,
+) error {
+	// Read the raw image checksum and its current chunk contents.
+	csumStored, err := readChecksumAtIndex(rawChecksumFile, chunkIndex)
+	if err != nil {
+		return err
+	}
+	chunkBuf := make([]byte, rawChecksumChunkSize)
+	if _, err := rawFile.Seek(int64(chunkStartPos), io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek to chunk start: %w", err)
+	}
+	if _, err := io.ReadFull(rawFile, chunkBuf); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return fmt.Errorf("failed to read current chunk data: %w", err)
+		}
+	}
+
+	csumCurrent := xxhash.Sum64(chunkBuf)
+
+	// Compute the offset between chunkStartPos (chunk start) and writeStartPos (write start)
+	bufOffset := writeStartPos - chunkStartPos
+
+	// Update chunkBuf according to record type
+	if tag == 'w' { // UPDATED DATA
+		writeBuf := chunkBuf[bufOffset : bufOffset+writeSize]
+		if _, err := io.ReadFull(diffFileReader, writeBuf); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return fmt.Errorf(
+					"diff data truncated (chunk=%d, needed=%d): %w",
+					chunkIndex, writeSize, err,
+				)
+			}
+			if errors.Is(err, csumio.ErrChecksumMismatch) {
+				return fmt.Errorf("failed to read partial chunk data: %w: %w", ErrChecksumMismatch, err)
+			}
+			return fmt.Errorf("failed to read partial chunk data: %w", err)
+		}
+	} else { // ZERO DATA
+		for i := bufOffset; i < bufOffset+writeSize; i++ {
+			chunkBuf[i] = 0
+		}
+	}
+
+	csumUpdated := xxhash.Sum64(chunkBuf)
+
+	// Crash-safe update method: csumStored reflects raw.img.csum, csumCurrent is the data we read,
+	// and csumUpdated is what the data will look like after applying the diff. Comparing them lets
+	// retries recover cleanly after crashes without extra journaling.
+	if csumStored == csumCurrent && csumCurrent == csumUpdated {
+		// Both files already updated in a previous run; nothing left to do.
+		return nil
+	} else if csumStored == csumUpdated && csumCurrent != csumUpdated {
+		// Checksum already advanced; data will be rewritten below.
+	} else if csumStored == csumCurrent && csumUpdated != csumCurrent {
+		// Data and checksum both still old; proceed with the write.
+	} else {
+		return ErrChecksumMismatch
+	}
+
+	// Update the checksum first.
+	if err := writeChecksumAtChunk(rawChecksumFile, chunkIndex, csumUpdated); err != nil {
+		return err
+	}
+
+	// Ensure the checksum is persisted to storage.
+	if err := rawChecksumFile.Sync(); err != nil {
+		return fmt.Errorf("failed to sync checksum file: %w", err)
+	}
+
+	// Once the checksum is persisted we can safely overwrite the raw.img.
+	if _, err := rawFile.Seek(int64(writeStartPos), io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek to write start: %w", err)
+	}
+	if _, err := rawFile.Write(chunkBuf[bufOffset : bufOffset+writeSize]); err != nil {
+		return fmt.Errorf("failed to write updated chunk data: %w", err)
+	}
+
+	return nil
+}
+
+func writeChecksumAtChunk(checksumFile *os.File, chunkIndex uint64, checksum uint64) error {
+	buf := make([]byte, csumio.ChecksumLen)
+	binary.LittleEndian.PutUint64(buf, checksum)
+	if _, err := checksumFile.Seek(int64(chunkIndex*csumio.ChecksumLen), io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek in checksum file: %w", err)
+	}
+	if _, err := checksumFile.Write(buf); err != nil {
+		return fmt.Errorf("failed to write checksum: %w", err)
+	}
+	return nil
+}
+
+func readChecksumAtIndex(checksumFile *os.File, chunkIndex uint64) (uint64, error) {
+	buf := make([]byte, csumio.ChecksumLen)
+	if _, err := checksumFile.Seek(int64(chunkIndex*csumio.ChecksumLen), io.SeekStart); err != nil {
+		return 0, fmt.Errorf("failed to seek in checksum file: %w", err)
+	}
+	if _, err := io.ReadFull(checksumFile, buf); err != nil {
+		return 0, fmt.Errorf("failed to read checksum: %w", err)
+	}
+	return binary.LittleEndian.Uint64(buf), nil
 }
 
 func zerooutBlockDevice(dstFile *os.File, offset, length uint64) error {
@@ -448,4 +829,13 @@ func readDiffHeaderAndMetadata(diffFile *bufio.Reader) (*diffMetadata, error) {
 			return diffMetadata, nil
 		}
 	}
+}
+
+func calcZeroChecksum(chunkSize uint64) uint64 {
+	zeroBuf := make([]byte, chunkSize)
+	return xxhash.Sum64(zeroBuf)
+}
+
+func getChecksumFilePath(imageFilePath string) string {
+	return imageFilePath + ".csum"
 }


### PR DESCRIPTION
In this pull request, checksum verification functionality has been added to `applyDiffToRawImage` in `rbd.go`. This feature is currently disabled to maintain compatibility with Job. It will be enabled when the Job integration is completed in PR https://github.com/cybozu-go/fin/pull/187. But, tests for `applyDiffToRawImage` have been added in `rbd_test.go` and it has been confirmed that it works correctly.