### PR TITLE
e2e: remove android directory to free up disk space

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Free up disk space
         run: |
           df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/.ghcup
+          sudo rm -rf /usr/share/dotnet /usr/local/.ghcup /usr/local/lib/android
           df -h /
 
       - uses: ./.github/actions/set-up-kvm-for-e2e-tests
@@ -54,6 +54,8 @@ jobs:
       - name: Load image into minikube
         run: |
             make -C test/e2e image-tar-load
+            # Display disk usage after loading image
+            df -h /
 
       - name: Launch rook-ceph and deploy components
         run: |


### PR DESCRIPTION
At the time of this commit, removing the android directory reduced the root
filesystem usage from 48G to 39G.
```
Before:
  Filesystem      Size  Used Avail Use% Mounted on
  /dev/root        73G   48G   25G  66% /
After:
  Filesystem      Size  Used Avail Use% Mounted on
  /dev/root        73G   39G   34G  54% /
```