### PR TITLE
feat: add FinRestore-related metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
+	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.32.0
@@ -49,7 +50,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect


### PR DESCRIPTION
### Description

added below metrics.

- fin_restore_info
- fin_restore_status_condition
- fin_restore_creation_timestamp

### Example

```ini
# HELP fin_restore_creation_timestamp Creation timestamp of the FinRestore resource
# TYPE fin_restore_creation_timestamp gauge
fin_restore_creation_timestamp{finrestore="test-1-b",namespace="default"} 1.763536282e+09
# HELP fin_restore_info Information about FinRestore and associated PVC
# TYPE fin_restore_info gauge
fin_restore_info{ceph_namespace="rook-ceph",finrestore="test-1-b",namespace="default",pvc="test-1-b-restore-a",pvc_namespace="default"} 1
# HELP fin_restore_status_condition Current restore status condition per FinRestore
# TYPE fin_restore_status_condition gauge
fin_restore_status_condition{condition="ReadyToUse",finrestore="test-1-b",namespace="default",status="False"} 0
fin_restore_status_condition{condition="ReadyToUse",finrestore="test-1-b",namespace="default",status="True"} 1
fin_restore_status_condition{condition="ReadyToUse",finrestore="test-1-b",namespace="default",status="Unknown"} 0
```