### PR TITLE
fix: ignore node on auto deletion

### DIFF
--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -1202,7 +1202,7 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 
 			By("calling deleteOldFinBackup()")
 			err := reconciler.deleteOldFinBackup(ctx, finBackup, pvc)
-			Expect(err).To(MatchError(ContainSubstring("only one older FinBackup is allowed on node")))
+			Expect(err).To(MatchError(ContainSubstring("only one older FinBackup is allowed")))
 
 			By("verifying both older FinBackups exist")
 			var fb finv1.FinBackup
@@ -1217,7 +1217,7 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 		})
 
 		// Description:
-		//   Retain the older FinBackup that resides on a different node.
+		//   Delete the older FinBackup that resides on a different node.
 		//
 		// Preconditions:
 		//   - A backup-target PVC and PV exist.
@@ -1231,8 +1231,8 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 		//
 		// Assert:
 		//   - deleteOldFinBackup() returns no error.
-		//   - The older FinBackup on the other node exists.
-		It("should retain the older FinBackup on a different node", func(ctx SpecContext) {
+		//   - The older FinBackup on the different node is deleted.
+		It("should delete the older FinBackup on a different node", func(ctx SpecContext) {
 			By("creating the newer FinBackup on a different node")
 			finBackup = newFinBackup(ctx, "finbackup-test", "different-node", labels, 2)
 
@@ -1240,10 +1240,10 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 			err := reconciler.deleteOldFinBackup(ctx, finBackup, pvc)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			By("verifying the older FinBackup on the other node exists")
+			By("verifying the older FinBackup on the different node is deleted")
 			var fb finv1.FinBackup
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(oldFinBackup), &fb)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
 
 	})

--- a/internal/webhook/v1/finbackup_webhook.go
+++ b/internal/webhook/v1/finbackup_webhook.go
@@ -75,7 +75,7 @@ func (v *FinBackupCustomValidator) ValidateDelete(ctx context.Context, obj runti
 		return nil, fmt.Errorf("expected a FinBackup object but got %T", obj)
 	}
 
-	// Retrieve the list of FinBackups with the same target.Spec.Node and targetPVCName.
+	// Retrieve the list of FinBackups with the same targetPVCName.
 	// Deny deletion if any FinBackup has a snapID smaller than target.SnapID.
 	targetPVCName := target.Spec.PVC
 	targetPVCNamespace := target.Spec.PVCNamespace
@@ -106,8 +106,7 @@ func (v *FinBackupCustomValidator) ValidateDelete(ctx context.Context, obj runti
 
 	relatedBackups := make([]finv1.FinBackup, 0, len(list.Items))
 	for _, b := range list.Items {
-		if b.Spec.Node != target.Spec.Node ||
-			b.Spec.PVC != targetPVCName ||
+		if b.Spec.PVC != targetPVCName ||
 			b.Spec.PVCNamespace != targetPVCNamespace {
 			continue
 		}


### PR DESCRIPTION
- Removed the test case that covers different nodes from the full backup scenario.
- Added the node information to the message since FinBackups on other nodes also
  became deletion targets
