### PR TITLE
fix: do not delete metrics for pvc on finbackup deletion

### DIFF
--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -528,7 +528,6 @@ func (r *FinBackupReconciler) reconcileDelete(
 		logger.Error(err, "failed to remove finalizer")
 		return ctrl.Result{}, err
 	}
-	metrics.DeleteBackupMetrics(backup, r.cephClusterNamespace)
 
 	/*
 		The following Get loop is to make the deletion
@@ -1133,7 +1132,7 @@ func (r *FinBackupReconciler) reconcileVerification(
 	logger := log.FromContext(ctx)
 	if r.checkSkipVerificationCondition(backup) {
 		logger.Info("Set metrics and skip verification as per condition")
-		metrics.SetBackupDurationSeconds(backup, finv1.BackupConditionStoredToNode, r.cephClusterNamespace, isFullBackup(backup))
+		metrics.SetBackupDurationSeconds(backup, finv1.BackupConditionStoredToNode, r.cephClusterNamespace)
 		metrics.SetBackupCreateStatus(backup, r.cephClusterNamespace, false, isFullBackup(backup))
 		return r.skipVerification(ctx, backup)
 	}
@@ -1176,7 +1175,7 @@ func (r *FinBackupReconciler) reconcileVerification(
 	}
 
 	logger.Info("Verification completed successfully")
-	metrics.SetBackupDurationSeconds(backup, finv1.BackupConditionVerified, r.cephClusterNamespace, isFullBackup(backup))
+	metrics.SetBackupDurationSeconds(backup, finv1.BackupConditionVerified, r.cephClusterNamespace)
 	metrics.SetBackupCreateStatus(backup, r.cephClusterNamespace, false, isFullBackup(backup))
 	return ctrl.Result{}, nil
 }

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -102,7 +102,7 @@ func DeleteFinBackupConfigInfo(fbc *finv1.FinBackupConfig, cephNamespace string)
 	finbackupconfigInfo.DeleteLabelValues(cephNamespace, fbc.Spec.PVC, fbc.Spec.PVCNamespace, fbc.Namespace, fbc.Name, fbc.Spec.Node)
 }
 
-func SetBackupDurationSeconds(fb *finv1.FinBackup, untilCondition, cephNamespace string, fullBackup bool) {
+func SetBackupDurationSeconds(fb *finv1.FinBackup, untilCondition, cephNamespace string) {
 	if fb == nil {
 		return
 	}
@@ -129,15 +129,6 @@ func SetBackupCreateStatus(fb *finv1.FinBackup, cephNamespace string, inProgress
 	}
 	backupCreateStatus.WithLabelValues(cephNamespace, fb.Spec.PVCNamespace, fb.Spec.PVC, backupKindFull).Set(fullValue)
 	backupCreateStatus.WithLabelValues(cephNamespace, fb.Spec.PVCNamespace, fb.Spec.PVC, backupKindIncremental).Set(incrementalValue)
-}
-
-func DeleteBackupMetrics(fb *finv1.FinBackup, cephNamespace string) {
-	if fb == nil {
-		return
-	}
-	backupCreateStatus.DeleteLabelValues(cephNamespace, fb.Spec.PVCNamespace, fb.Spec.PVC, backupKindFull)
-	backupCreateStatus.DeleteLabelValues(cephNamespace, fb.Spec.PVCNamespace, fb.Spec.PVC, backupKindIncremental)
-	backupDurationSeconds.DeleteLabelValues(cephNamespace, fb.Spec.PVC, fb.Spec.PVCNamespace)
 }
 
 func SetRestoreInfo(fr *finv1.FinRestore, cephNamespace, pvcNamespace, pvcName string) {


### PR DESCRIPTION
fin_backup_create_status and fin_backup_duration_seconds are not specific to FinBackup. In fact, these metrics does not have FinBackup's information. So we shouldn't delete these metrics on FinBackup's deletion.

In addition, remove an unsed function parameter as a cleanup.