### PR TITLE
fix: return errChecksumMismatch when checksum data size is insufficient

### DIFF
--- a/internal/pkg/csumio/csumreader.go
+++ b/internal/pkg/csumio/csumreader.go
@@ -55,6 +55,9 @@ func (cr *Reader) Read(p []byte) (int, error) {
 			checksumBytes := make([]byte, ChecksumLen)
 			_, err := io.ReadFull(cr.checksumReader, checksumBytes)
 			if err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					return 0, fmt.Errorf("%w: checksum data is shorter than expected", ErrChecksumMismatch)
+				}
 				return 0, fmt.Errorf("failed to read checksum: %w", err)
 			}
 

--- a/internal/pkg/csumio/csumreader_test.go
+++ b/internal/pkg/csumio/csumreader_test.go
@@ -61,6 +61,37 @@ func TestReader_ChecksumMismatch_VerificationEnabled(t *testing.T) {
 	}
 }
 
+func TestReader_ChecksumShorterThanData(t *testing.T) {
+	// Description:
+	// Check that a short checksum file returns ErrChecksumMismatch.
+	//
+	// Arrange:
+	// - Data file has exactly one chunk.
+	// - Checksum file is shorter than the required checksum length.
+	//
+	// Act:
+	// Read once with checksum verification enabled.
+	//
+	// Assert:
+	// ErrChecksumMismatch is returned.
+
+	// Arrange
+	chunkSize := csumio.MinimumChunkSize
+	data := bytes.Repeat([]byte("a"), chunkSize)
+	truncatedChecksum := []byte{0x01}
+
+	reader, err := csumio.NewReader(bytes.NewReader(data), bytes.NewReader(truncatedChecksum), chunkSize, true)
+	require.NoError(t, err)
+
+	buf := make([]byte, chunkSize)
+
+	// Act
+	_, err = reader.Read(buf)
+
+	// Assert
+	assert.ErrorIs(t, err, csumio.ErrChecksumMismatch)
+}
+
 func TestReader_ChecksumMismatch_VerificationDisabled(t *testing.T) {
 	// Description:
 	// Check that checksum verification is ignored when verification is disabled


### PR DESCRIPTION
Previously, csumio returned EOF when the checksum file was smaller than expected. Since data corruption can cause checksum files to become smaller, this change now handles such cases as checksum errors by returning errChecksumMismatch instead.