### PR TITLE
e2e: run tests on two Kubernetes versions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,11 @@ jobs:
           - incremental-backup
           - misc
           - finbackupconfig
+        kubernetes-version:
+          - "1.33.7"
+          - "1.34.4"
+    env:
+      KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TBD
 
 ### Conformed environments
 
-- Kubernetes cluster: v1.34.4+
+- Kubernetes cluster: v1.33, v1.34
 - Rook: v1.18.6+
 
 ## Contributing

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -2,7 +2,7 @@
 
 ## How to change the supported Kubernetes minor versions
 
-Fin depends on some Kubernetes repositories like `k8s.io/client-go` and supports only one Kubernetes version at a time.
+Fin depends on some Kubernetes repositories like `k8s.io/client-go` and supports two Kubernetes versions at a time.
 
 Issues and PRs related the latest upgrade task also help you understand how to upgrade the supported versions, so checking them together with this guide is recommended when you do this task.
 
@@ -10,14 +10,13 @@ Issues and PRs related the latest upgrade task also help you understand how to u
 
 #### Kubernetes
 
-Choose the next version and check the [release note](https://kubernetes.io/docs/setup/release/notes/).
-e.g. 1.17 -> 1.18
+When upgrading, add the new version and drop the oldest to keep supporting two consecutive minor versions.
 
-To change the version, edit the following files.
+Choose the appropriate versions and check the [release note](https://kubernetes.io/docs/setup/release/notes/).
 
-<!--
-- `.github/workflows/e2e.yaml`
--->
+To change the versions, edit the following files.
+
+- `.github/workflows/e2e.yaml` (update the `kubernetes-version` entries in the matrix)
 - `README.md`
 - `versions.mk`
 


### PR DESCRIPTION
Add a kubernetes-version matrix to the e2e workflow so that all test suites run on both v1.33 and v1.34. Update docs/maintenance.md and README.md accordingly.