### PR TITLE
restore: restore unnecessary secret ref from static volumes

### DIFF
--- a/internal/controller/finrestore_controller.go
+++ b/internal/controller/finrestore_controller.go
@@ -493,9 +493,8 @@ func (r *FinRestoreReconciler) createRestoreJobPVIfNotExists(
 			VolumeMode:       ptr.To(corev1.PersistentVolumeBlock),
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
-					ControllerExpandSecretRef: restorePV.Spec.CSI.ControllerExpandSecretRef,
-					Driver:                    restorePV.Spec.CSI.Driver,
-					NodeStageSecretRef:        restorePV.Spec.CSI.NodeStageSecretRef,
+					Driver:             restorePV.Spec.CSI.Driver,
+					NodeStageSecretRef: restorePV.Spec.CSI.NodeStageSecretRef,
 					VolumeAttributes: map[string]string{
 						"clusterID":     restorePV.Spec.CSI.VolumeAttributes["clusterID"],
 						"imageFeatures": restorePV.Spec.CSI.VolumeAttributes["imageFeatures"],


### PR DESCRIPTION
controllerExpandSecretRef is not necessary for ceph-csi static volume since volume expansion is not supported for this kind of volumes. In addition, this reference sn't written in spec:

https://github.com/ceph/ceph-csi/blob/devel/docs/static-pvc.md