### PR TITLE
ci: add permissions

### DIFF
--- a/.github/workflows/check-do-not-merge.yaml
+++ b/.github/workflows/check-do-not-merge.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   check-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 env:
   # Github runner's extra disk is mounted on the /mnt directory.
   MINIKUBE_HOME: "/mnt/"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,10 @@ on:
       - "**/*.md"
     branches:
       - "main"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "build"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     name: "release"


### PR DESCRIPTION
Add `permissions` field to the CI workflows.

The following workflows are tested on this PR:

- check-do-not-merge.yaml
- e2e.yaml
- main.yaml

However, the following workflows cannot be tested (I think), so I'd like to merge them first and fix any issues later.

- release.yaml
