### PR TITLE
  controller: add MetadataCorrupted condition to stop reconciliation on db corruption

### DIFF
--- a/api/v1/finbackup_types.go
+++ b/api/v1/finbackup_types.go
@@ -59,6 +59,7 @@ const (
 	BackupConditionVerificationSkipped = "VerificationSkipped"
 	BackupConditionChecksumMismatched  = "ChecksumMismatched"
 	BackupConditionAutoDeleteCompleted = "AutoDeleteCompleted"
+	BackupConditionMetadataCorrupted   = "MetadataCorrupted"
 )
 
 //+kubebuilder:object:root=true
@@ -106,6 +107,10 @@ func (fb *FinBackup) IsVerificationSkipped() bool {
 
 func (fb *FinBackup) IsChecksumMismatched() bool {
 	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionChecksumMismatched)
+}
+
+func (fb *FinBackup) IsMetadataCorrupted() bool {
+	return meta.IsStatusConditionTrue(fb.Status.Conditions, BackupConditionMetadataCorrupted)
 }
 
 func (fb *FinBackup) IsAutoDeleteCompleted() bool {

--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -206,6 +206,18 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
+func (r *FinBackupReconciler) setFinBackupChecksumMismatched(ctx context.Context, backup *finv1.FinBackup) (ctrl.Result, error) {
+	if _, err := patchFinBackupCondition(ctx, r.Client, backup, metav1.Condition{
+		Type:    finv1.BackupConditionChecksumMismatched,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ChecksumMismatch",
+		Message: "Data corruption detected: checksum mismatch",
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
 func (r *FinBackupReconciler) setFinBackupMetadataCorrupted(ctx context.Context, backup *finv1.FinBackup) (ctrl.Result, error) {
 	if _, err := patchFinBackupCondition(ctx, r.Client, backup, metav1.Condition{
 		Type:    finv1.BackupConditionMetadataCorrupted,
@@ -374,15 +386,7 @@ func (r *FinBackupReconciler) reconcileBackup(
 	case JobStatusInProgress:
 		return ctrl.Result{}, errNonRetryableReconcile
 	case JobStatusFailedWithExitCode2:
-		if _, err := patchFinBackupCondition(ctx, r.Client, &backup, metav1.Condition{
-			Type:    finv1.BackupConditionChecksumMismatched,
-			Status:  metav1.ConditionTrue,
-			Reason:  "ChecksumMismatch",
-			Message: "Data corruption detected: checksum mismatch",
-		}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition to true: %w", err)
-		}
-		return ctrl.Result{}, nil
+		return r.setFinBackupChecksumMismatched(ctx, &backup)
 	case JobStatusFailedWithExitCode4:
 		return r.setFinBackupMetadataCorrupted(ctx, &backup)
 	default:
@@ -563,15 +567,7 @@ func (r *FinBackupReconciler) reconcileDelete(
 		case JobStatusInProgress:
 			return ctrl.Result{}, nil
 		case JobStatusFailedWithExitCode2:
-			if _, err := patchFinBackupCondition(ctx, r.Client, backup, metav1.Condition{
-				Type:    finv1.BackupConditionChecksumMismatched,
-				Status:  metav1.ConditionTrue,
-				Reason:  "ChecksumMismatch",
-				Message: "Data corruption detected: checksum mismatch",
-			}); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition to true: %w", err)
-			}
-			return ctrl.Result{}, nil
+			return r.setFinBackupChecksumMismatched(ctx, backup)
 		case JobStatusFailedWithExitCode4:
 			return r.setFinBackupMetadataCorrupted(ctx, backup)
 		default:
@@ -1450,15 +1446,7 @@ func (r *FinBackupReconciler) reconcileVerification(
 	case JobStatusInProgress:
 		return ctrl.Result{}, nil
 	case JobStatusFailedWithExitCode2:
-		if _, err := patchFinBackupCondition(ctx, r.Client, backup, metav1.Condition{
-			Type:    finv1.BackupConditionChecksumMismatched,
-			Status:  metav1.ConditionTrue,
-			Reason:  "ChecksumMismatch",
-			Message: "Data corruption detected: checksum mismatch",
-		}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition to true: %w", err)
-		}
-		return ctrl.Result{}, nil
+		return r.setFinBackupChecksumMismatched(ctx, backup)
 	case JobStatusFailedWithExitCode3:
 		if _, err := patchFinBackupCondition(ctx, r.Client, backup, metav1.Condition{
 			Type:    finv1.BackupConditionVerified,

--- a/internal/controller/finbackup_controller.go
+++ b/internal/controller/finbackup_controller.go
@@ -156,6 +156,11 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		metrics.SetBackupCreateStatus(&backup, r.cephClusterNamespace, *status, isFullBackup(&backup))
 	}
 
+	if backup.IsMetadataCorrupted() {
+		logger.Info("metadata corruption detected; skip reconciling")
+		return ctrl.Result{}, nil
+	}
+
 	if backup.IsChecksumMismatched() {
 		annotations := backup.GetAnnotations()
 		if annotations != nil && annotations[annotationSkipChecksumVerify] != annotationValueTrue {
@@ -198,6 +203,18 @@ func (r *FinBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 	logger.Info("automatic deletion of old FinBackup completed")
+	return ctrl.Result{}, nil
+}
+
+func (r *FinBackupReconciler) setFinBackupMetadataCorrupted(ctx context.Context, backup *finv1.FinBackup) (ctrl.Result, error) {
+	if _, err := patchFinBackupCondition(ctx, r.Client, backup, metav1.Condition{
+		Type:    finv1.BackupConditionMetadataCorrupted,
+		Status:  metav1.ConditionTrue,
+		Reason:  "MetadataCorrupted",
+		Message: "Backup metadata corruption detected",
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set FinBackup MetadataCorrupted condition: %w", err)
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -366,6 +383,8 @@ func (r *FinBackupReconciler) reconcileBackup(
 			return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition to true: %w", err)
 		}
 		return ctrl.Result{}, nil
+	case JobStatusFailedWithExitCode4:
+		return r.setFinBackupMetadataCorrupted(ctx, &backup)
 	default:
 		return ctrl.Result{}, fmt.Errorf("unknown backup job status: %d", jobStatus.Status)
 	}
@@ -457,6 +476,7 @@ func (r *FinBackupReconciler) createSnapshot(ctx context.Context, backup *finv1.
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
+//nolint:gocyclo
 func (r *FinBackupReconciler) reconcileDelete(
 	ctx context.Context,
 	backup *finv1.FinBackup,
@@ -507,14 +527,20 @@ func (r *FinBackupReconciler) reconcileDelete(
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get cleanup job: %w", err)
 		}
-		done, err := jobCompleted(&cleanupJob)
+		jobStatus, err := CheckJobStatus(ctx, r.Client, cleanupJobName(backup), r.cephClusterNamespace)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to check cleanup job status: %w", err)
 		}
-		if !done {
+		switch jobStatus.Status {
+		case JobStatusComplete:
+			// do nothing
+		case JobStatusInProgress:
 			return ctrl.Result{}, nil
+		case JobStatusFailedWithExitCode4:
+			return r.setFinBackupMetadataCorrupted(ctx, backup)
+		default:
+			return ctrl.Result{}, fmt.Errorf("unknown cleanup job status: %d", jobStatus.Status)
 		}
-
 		err = r.createOrUpdateDeletionJob(ctx, backup)
 		if err != nil {
 			logger.Error(err, "failed to create or update deletion job")
@@ -527,7 +553,7 @@ func (r *FinBackupReconciler) reconcileDelete(
 			return ctrl.Result{}, fmt.Errorf("failed to get deletion job: %w", err)
 		}
 
-		jobStatus, err := CheckJobStatus(ctx, r.Client, deletionJobName(backup), r.cephClusterNamespace)
+		jobStatus, err = CheckJobStatus(ctx, r.Client, deletionJobName(backup), r.cephClusterNamespace)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to check deletion job status: %w", err)
 		}
@@ -546,6 +572,8 @@ func (r *FinBackupReconciler) reconcileDelete(
 				return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition to true: %w", err)
 			}
 			return ctrl.Result{}, nil
+		case JobStatusFailedWithExitCode4:
+			return r.setFinBackupMetadataCorrupted(ctx, backup)
 		default:
 			return ctrl.Result{}, fmt.Errorf("unknown deletion job status: %d", jobStatus.Status)
 		}
@@ -980,7 +1008,7 @@ func (r *FinBackupReconciler) createOrUpdateBackupJob(
 					OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
 						ContainerName: ptr.To("backup"),
 						Operator:      batchv1.PodFailurePolicyOnExitCodesOpIn,
-						Values:        []int32{2},
+						Values:        []int32{2, 4},
 					},
 				},
 			},
@@ -1213,7 +1241,7 @@ func (r *FinBackupReconciler) createOrUpdateDeletionJob(ctx context.Context, bac
 					OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
 						ContainerName: ptr.To("deletion"),
 						Operator:      batchv1.PodFailurePolicyOnExitCodesOpIn,
-						Values:        []int32{2},
+						Values:        []int32{2, 4},
 					},
 				},
 			},
@@ -1327,7 +1355,7 @@ func (r *FinBackupReconciler) createOrUpdateCleanupJob(ctx context.Context, back
 			RunAsUser:    ptr.To(int64(10000)),
 		}
 
-		job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+		job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 
 		job.Spec.Template.Spec.Containers = []corev1.Container{
 			{
@@ -1373,6 +1401,19 @@ func (r *FinBackupReconciler) createOrUpdateCleanupJob(ctx context.Context, back
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: finVolumePVCName(backup),
+					},
+				},
+			},
+		}
+
+		job.Spec.PodFailurePolicy = &batchv1.PodFailurePolicy{
+			Rules: []batchv1.PodFailurePolicyRule{
+				{
+					Action: batchv1.PodFailurePolicyActionFailJob,
+					OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
+						ContainerName: ptr.To("cleanup"),
+						Operator:      batchv1.PodFailurePolicyOnExitCodesOpIn,
+						Values:        []int32{4},
 					},
 				},
 			},
@@ -1428,6 +1469,8 @@ func (r *FinBackupReconciler) reconcileVerification(
 			return ctrl.Result{}, fmt.Errorf("failed to set FinBackup Verified condition to false: %w", err)
 		}
 		return ctrl.Result{}, nil
+	case JobStatusFailedWithExitCode4:
+		return r.setFinBackupMetadataCorrupted(ctx, backup)
 	default:
 		return ctrl.Result{}, fmt.Errorf("unknown verification job status: %d", jobStatus.Status)
 	}
@@ -1550,7 +1593,7 @@ func (r *FinBackupReconciler) createOrUpdateVerificationJob(
 					OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
 						ContainerName: ptr.To("verification"),
 						Operator:      batchv1.PodFailurePolicyOnExitCodesOpIn,
-						Values:        []int32{2, 3},
+						Values:        []int32{2, 3, 4},
 					},
 				},
 			},

--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -1083,6 +1083,253 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 		})
 	})
 
+	Describe("fin.sqlite3 corruption (MetadataCorrupted)", func() {
+		var pvc *corev1.PersistentVolumeClaim
+		var pv *corev1.PersistentVolume
+
+		BeforeEach(func(ctx SpecContext) {
+			By("creating a pair of PVC and PV for fin.sqlite3 corruption cases")
+			pvc, pv = NewPVCAndPV(normalSC, userNamespace, utils.GetUniqueName("pvc-csum-"), utils.GetUniqueName("pv-csum-"), rbdImageName)
+			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			By("cleaning up PVC and PV")
+			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
+		})
+
+		It("should set MetadataCorrupted=True when backup Job exits with code 4", func(ctx SpecContext) {
+			// Description:
+			//   Ensure that when backup Job detects fin.sqlite3 corruption (exit code 4),
+			//   the FinBackup is set to MetadataCorrupted=True and subsequent
+			//   reconciliation is stopped.
+			//
+			// Arrange:
+			//   - Create a full FinBackup to trigger backup Job creation.
+			//
+			// Act:
+			//   - Wait for the backup Job to be created.
+			//   - Make the backup Job fail with exit code 4 (fin.sqlite3 corruption).
+			//
+			// Assert:
+			//   - The FinBackup has MetadataCorrupted=True condition.
+			//   - The FinBackup does not have StoredToNode=True condition.
+
+			// Arrange
+			By("creating a full FinBackup")
+			finbackup1 := NewFinBackup(workNamespace, utils.GetUniqueName("fb-full-"), pvc.Name, pvc.Namespace, "test-node")
+			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
+
+			// Act
+			By("waiting for the backup Job to be created")
+			backupJobKey := client.ObjectKey{Namespace: cephNamespace, Name: backupJobName(finbackup1)}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				var job batchv1.Job
+				g.Expect(k8sClient.Get(ctx, backupJobKey, &job)).To(Succeed())
+			}, "5s", "1s").WithContext(ctx).Should(Succeed())
+
+			By("making the backup Job fail with exit code 4")
+			makeJobFailWithExitCode(ctx, backupJobKey.Name, 4)
+
+			// Assert
+			By("checking the FinBackup has the condition MetadataCorrupted=True")
+			Eventually(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.IsMetadataCorrupted()).Should(BeTrue())
+			}, "5s", "1s").Should(Succeed())
+
+			By("checking the FinBackup does not have StoredToNode=True condition")
+			Consistently(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.IsStoredToNode()).Should(BeFalse())
+			}, "3s", "1s").Should(Succeed())
+		})
+
+		It("should set MetadataCorrupted=True when verification Job exits with code 4", func(ctx SpecContext) {
+			// Description:
+			//   Ensure that when the verification Job exits with code 4 (fin.sqlite3 corruption),
+			//   FinBackup is set to MetadataCorrupted=True and subsequent reconciliation is stopped.
+			//
+			// Arrange:
+			//   - Create a full FinBackup and make it StoredToNode.
+			//
+			// Act:
+			//   - Make the verification Job fail with exit code 4.
+			//
+			// Assert:
+			//   - The FinBackup has MetadataCorrupted=True condition.
+			//   - The FinBackup does not have Verified=True condition.
+
+			// Arrange
+			By("creating a full FinBackup")
+			finbackup1 := NewFinBackup(workNamespace, utils.GetUniqueName("fb-full-"), pvc.Name, pvc.Namespace, "test-node")
+			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
+			MakeFinBackupStoredToNode(ctx, finbackup1)
+
+			// Act
+			By("making the verification Job fail with exit code 4")
+			makeJobFailWithExitCode(ctx, verificationJobName(finbackup1), 4)
+
+			// Assert
+			By("checking the FinBackup has the condition MetadataCorrupted=True")
+			Eventually(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.IsMetadataCorrupted()).Should(BeTrue())
+			}, "5s", "1s").Should(Succeed())
+
+			By("checking the FinBackup does not have Verified=True condition")
+			Consistently(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.IsVerifiedTrue()).Should(BeFalse())
+			}, "3s", "1s").Should(Succeed())
+		})
+
+		It("should set MetadataCorrupted=True when cleanup Job exits with code 4", func(ctx SpecContext) {
+			// Description:
+			//   Ensure that when cleanup Job detects fin.sqlite3 corruption (exit code 4),
+			//   the FinBackup is set to MetadataCorrupted=True and the deletion process
+			//   is stopped before the deletion Job is created.
+			//
+			// Arrange:
+			//   - Create a full FinBackup, make it StoredToNode and Verified.
+			//
+			// Act:
+			//   - Delete the FinBackup to trigger deletion reconciliation.
+			//   - Wait for cleanup Job to be created and make it fail with exit code 4.
+			//
+			// Assert:
+			//   - The FinBackup has MetadataCorrupted=True condition.
+			//   - The FinBackup has DeletionTimestamp set.
+			//   - The deletion process is stopped.
+			//   - No deletion Job is created.
+
+			// Arrange
+			By("creating a full FinBackup")
+			finbackup1 := NewFinBackup(workNamespace, utils.GetUniqueName("fb-full-"), pvc.Name, pvc.Namespace, "test-node")
+			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
+			MakeFinBackupStoredToNode(ctx, finbackup1)
+			MakeFinBackupVerified(ctx, finbackup1)
+
+			// Act
+			By("deleting the FinBackup to trigger deletion reconciliation")
+			Expect(k8sClient.Delete(ctx, finbackup1)).Should(Succeed())
+
+			By("waiting for the cleanup Job to be created")
+			cleanupJobKey := client.ObjectKey{Namespace: cephNamespace, Name: cleanupJobName(finbackup1)}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				var job batchv1.Job
+				g.Expect(k8sClient.Get(ctx, cleanupJobKey, &job)).To(Succeed())
+			}, "30s", "1s").WithContext(ctx).Should(Succeed())
+
+			By("making the cleanup Job fail with exit code 4")
+			makeJobFailWithExitCode(ctx, cleanupJobKey.Name, 4)
+
+			// Assert
+			By("checking the FinBackup has MetadataCorrupted=True and deletion is stopped")
+			Eventually(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.IsMetadataCorrupted()).Should(BeTrue())
+				g.Expect(updated.DeletionTimestamp.IsZero()).Should(BeFalse())
+			}, "5s", "1s").Should(Succeed())
+
+			By("confirming the deletion process is stopped")
+			Consistently(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.Finalizers).Should(ContainElement("finbackup.fin.cybozu.io/finalizer"))
+			}, "3s", "1s").Should(Succeed())
+
+			By("checking no deletion Job is created")
+			ExpectNoJob(ctx, k8sClient, deletionJobName(finbackup1), cephNamespace)
+		})
+
+		It("should set MetadataCorrupted=True when deletion Job exits with code 4", func(ctx SpecContext) {
+			// Description:
+			//   Ensure that when deletion Job detects fin.sqlite3 corruption (exit code 4),
+			//   the FinBackup is set to MetadataCorrupted=True and the deletion process
+			//   is stopped.
+			//
+			// Arrange:
+			//   - Create a full FinBackup, make it StoredToNode and Verified.
+			//
+			// Act:
+			//   - Delete the FinBackup to trigger deletion reconciliation.
+			//   - Wait for cleanup Job to be created and make it succeed.
+			//   - Wait for deletion Job to be created and make it fail with exit code 4.
+			//
+			// Assert:
+			//   - The FinBackup has MetadataCorrupted=True condition.
+			//   - The FinBackup has DeletionTimestamp set.
+			//   - The deletion process is stopped.
+
+			// Arrange
+			By("creating a full FinBackup")
+			finbackup1 := NewFinBackup(workNamespace, utils.GetUniqueName("fb-full-"), pvc.Name, pvc.Namespace, "test-node")
+			Expect(k8sClient.Create(ctx, finbackup1)).Should(Succeed())
+			MakeFinBackupStoredToNode(ctx, finbackup1)
+			MakeFinBackupVerified(ctx, finbackup1)
+
+			// Act
+			By("deleting the FinBackup to trigger deletion reconciliation")
+			Expect(k8sClient.Delete(ctx, finbackup1)).Should(Succeed())
+
+			By("waiting for the cleanup Job to be created")
+			cleanupJobKey := client.ObjectKey{Namespace: cephNamespace, Name: cleanupJobName(finbackup1)}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				var job batchv1.Job
+				g.Expect(k8sClient.Get(ctx, cleanupJobKey, &job)).To(Succeed())
+			}, "30s", "1s").WithContext(ctx).Should(Succeed())
+
+			By("making the cleanup Job succeed")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				var job batchv1.Job
+				g.Expect(k8sClient.Get(ctx, cleanupJobKey, &job)).To(Succeed())
+				makeJobSucceeded(&job)
+				g.Expect(k8sClient.Status().Update(ctx, &job)).Should(Succeed())
+			}, "5s", "1s").WithContext(ctx).Should(Succeed())
+
+			By("waiting for the deletion Job to be created")
+			delJobKey := client.ObjectKey{Namespace: cephNamespace, Name: deletionJobName(finbackup1)}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				var job batchv1.Job
+				g.Expect(k8sClient.Get(ctx, delJobKey, &job)).To(Succeed())
+			}, "30s", "1s").WithContext(ctx).Should(Succeed())
+
+			By("making the deletion Job fail with exit code 4")
+			makeJobFailWithExitCode(ctx, delJobKey.Name, 4)
+
+			// Assert
+			By("checking the FinBackup has MetadataCorrupted=True and deletion is stopped")
+			Eventually(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.IsMetadataCorrupted()).Should(BeTrue())
+				g.Expect(updated.DeletionTimestamp.IsZero()).Should(BeFalse())
+			}, "5s", "1s").Should(Succeed())
+
+			By("confirming the deletion process is stopped")
+			Consistently(func(g Gomega) {
+				var updated finv1.FinBackup
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup1), &updated)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(updated.Finalizers).Should(ContainElement("finbackup.fin.cybozu.io/finalizer"))
+			}, "3s", "1s").Should(Succeed())
+		})
+	})
+
 	Describe("Auto Deletion Feature", func() {
 		var pvc *corev1.PersistentVolumeClaim
 
@@ -1229,6 +1476,60 @@ var _ = Describe("FinBackup Controller Reconcile Test", Ordered, func() {
 		AfterEach(func(ctx SpecContext) {
 			Expect(k8sClient.Delete(ctx, finbackup)).Should(Succeed())
 			DeletePVCAndPV(ctx, pvc2.Namespace, pvc2.Name)
+		})
+
+		It("should neither return an error nor create a backup job during reconciliation", func(ctx SpecContext) {
+			By("reconciling the FinBackup")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finbackup)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("checking that no backup job is created")
+			ExpectNoJob(ctx, k8sClient, backupJobName(finbackup), cephNamespace)
+		})
+	})
+
+	// Description:
+	//   Ensure that a FinBackup already marked MetadataCorrupted=True is not
+	//   reconciled further: the reconciler must exit early without creating a
+	//   backup job.
+	//
+	// Arrange:
+	//   - Create a pair of PVC and PV.
+	//   - Create a FinBackup with MetadataCorrupted=True set on its status.
+	//
+	// Act:
+	//   - Run FinBackup Controller's Reconcile().
+	//
+	// Assert:
+	//   - The reconciler does not return any errors.
+	//   - The reconciler does not create a backup job.
+	Context("Prevent reconciliation of a FinBackup with MetadataCorrupted=True", func() {
+		var pvc *corev1.PersistentVolumeClaim
+		var pv *corev1.PersistentVolume
+		var finbackup *finv1.FinBackup
+
+		BeforeEach(func(ctx SpecContext) {
+			By("creating a pair of PVC and PV")
+			pvc, pv = NewPVCAndPV(normalSC, userNamespace, "test-pvc-corrupted", "test-pv-corrupted", rbdImageName)
+			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
+
+			By("creating a FinBackup with MetadataCorrupted=True")
+			finbackup = NewFinBackup(workNamespace, "test-fin-backup-corrupted", pvc.Name, pvc.Namespace, "test-node")
+			Expect(k8sClient.Create(ctx, finbackup)).Should(Succeed())
+			finbackup.Status.Conditions = append(finbackup.Status.Conditions, metav1.Condition{
+				Type:               finv1.BackupConditionMetadataCorrupted,
+				Status:             metav1.ConditionTrue,
+				Reason:             "MetadataCorrupted",
+				Message:            "fin.sqlite3 corruption detected",
+				LastTransitionTime: metav1.Now(),
+			})
+			Expect(k8sClient.Status().Update(ctx, finbackup)).Should(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, finbackup)).Should(Succeed())
+			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
 		})
 
 		It("should neither return an error nor create a backup job during reconciliation", func(ctx SpecContext) {

--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -913,6 +913,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			expectChecksumChunkSizesInBackupJob(ctx, backupJobName(finbackup1))
 		})
 
+		//nolint:dupl
 		It("should set ChecksumMismatched=True when backup Job exits with code 2", func(ctx SpecContext) {
 			// Description:
 			//   Ensure that when backup Job detects a checksum mismatch (exit code 2),
@@ -1008,6 +1009,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			}, "3s", "1s").Should(Succeed())
 		})
 
+		//nolint:dupl
 		It("should set ChecksumMismatched=True when deletion Job exits with code 2", func(ctx SpecContext) {
 			// Description:
 			//   Ensure that when deletion Job detects a checksum mismatch (exit code 2),
@@ -1099,6 +1101,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
 		})
 
+		//nolint:dupl
 		It("should set MetadataCorrupted=True when backup Job exits with code 4", func(ctx SpecContext) {
 			// Description:
 			//   Ensure that when backup Job detects fin.sqlite3 corruption (exit code 4),
@@ -1150,6 +1153,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			}, "3s", "1s").Should(Succeed())
 		})
 
+		//nolint:dupl
 		It("should set MetadataCorrupted=True when verification Job exits with code 4", func(ctx SpecContext) {
 			// Description:
 			//   Ensure that when the verification Job exits with code 4 (fin.sqlite3 corruption),
@@ -1193,6 +1197,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			}, "3s", "1s").Should(Succeed())
 		})
 
+		//nolint:dupl
 		It("should set MetadataCorrupted=True when cleanup Job exits with code 4", func(ctx SpecContext) {
 			// Description:
 			//   Ensure that when cleanup Job detects fin.sqlite3 corruption (exit code 4),
@@ -1255,6 +1260,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 			ExpectNoJob(ctx, k8sClient, deletionJobName(finbackup1), cephNamespace)
 		})
 
+		//nolint:dupl
 		It("should set MetadataCorrupted=True when deletion Job exits with code 4", func(ctx SpecContext) {
 			// Description:
 			//   Ensure that when deletion Job detects fin.sqlite3 corruption (exit code 4),

--- a/internal/controller/finrestore_controller.go
+++ b/internal/controller/finrestore_controller.go
@@ -143,18 +143,23 @@ func (r *FinRestoreReconciler) reconcileCreateOrUpdate(
 		return ctrl.Result{}, nil
 	}
 
-	controllerutil.AddFinalizer(restore, FinRestoreFinalizerName)
-	err := r.Update(ctx, restore)
-	if err != nil {
-		logger.Error(err, "failed to add finalizer")
-		return ctrl.Result{}, err
+	if controllerutil.AddFinalizer(restore, FinRestoreFinalizerName) {
+		if err := r.Update(ctx, restore); err != nil {
+			logger.Error(err, "failed to add finalizer")
+			return ctrl.Result{}, err
+		}
 	}
 
 	var backup finv1.FinBackup
-	err = r.Get(ctx, client.ObjectKey{Name: restore.Spec.Backup, Namespace: restore.Namespace}, &backup)
+	err := r.Get(ctx, client.ObjectKey{Name: restore.Spec.Backup, Namespace: restore.Namespace}, &backup)
 	if err != nil {
 		logger.Error(err, "failed to get FinBackup", "name", restore.Spec.Backup, "namespace", restore.Namespace)
 		return ctrl.Result{}, err
+	}
+
+	if backup.IsMetadataCorrupted() {
+		logger.Info("backup metadata is corrupted; skip restore")
+		return ctrl.Result{}, nil
 	}
 
 	pvc, _, err := getBackupTargetPVCFromSpecOrStatus(ctx, r.Client, &backup)
@@ -258,6 +263,22 @@ func (r *FinRestoreReconciler) reconcileCreateOrUpdate(
 			return ctrl.Result{}, fmt.Errorf("failed to set FinBackup ChecksumMismatched condition: %w", err)
 		}
 		return ctrl.Result{}, nil
+	case JobStatusFailedWithExitCode4:
+		var backup finv1.FinBackup
+		err = r.Get(ctx, client.ObjectKey{Name: restore.Spec.Backup, Namespace: restore.Namespace}, &backup)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get FinBackup for metadata corrupted update: %w", err)
+		}
+		_, err = patchFinBackupCondition(ctx, r.Client, &backup, metav1.Condition{
+			Type:    finv1.BackupConditionMetadataCorrupted,
+			Status:  metav1.ConditionTrue,
+			Reason:  "MetadataCorrupted",
+			Message: "Backup metadata corruption detected",
+		})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set FinBackup MetadataCorrupted condition: %w", err)
+		}
+		return ctrl.Result{}, nil
 	default:
 		return ctrl.Result{}, fmt.Errorf("unknown restore job status: %d", jobStatus.Status)
 	}
@@ -327,7 +348,7 @@ func (r *FinRestoreReconciler) createOrUpdateRestoreJob(
 					OnExitCodes: &batchv1.PodFailurePolicyOnExitCodesRequirement{
 						ContainerName: ptr.To("restore"),
 						Operator:      batchv1.PodFailurePolicyOnExitCodesOpIn,
-						Values:        []int32{2},
+						Values:        []int32{2, 4},
 					},
 				},
 			},

--- a/internal/controller/finrestore_controller_test.go
+++ b/internal/controller/finrestore_controller_test.go
@@ -709,6 +709,128 @@ var _ = Describe("FinRestore Controller Reconcile Test", Ordered, func() {
 		})
 	})
 
+	Context("fin.sqlite3 corruption (MetadataCorrupted) features", func() {
+		var pvc *corev1.PersistentVolumeClaim
+
+		BeforeEach(func(ctx SpecContext) {
+			By("creating a pair of PVC and PV")
+			var pv *corev1.PersistentVolume
+			pvc, pv = NewPVCAndPV(normalSC, userNamespace, utils.GetUniqueName("pvc-mc-"), utils.GetUniqueName("pv-mc-"), rbdImageName)
+			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, pv)).Should(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			By("cleaning up PVC and PV")
+			DeletePVCAndPV(ctx, pvc.Namespace, pvc.Name)
+		})
+
+		It("should set MetadataCorrupted=True on FinBackup when restore Job exits with code 4", func(ctx SpecContext) {
+			// Description:
+			//   Ensure that when restore Job detects fin.sqlite3 corruption (exit code 4),
+			//   the FinBackup is set to MetadataCorrupted=True.
+			//
+			// Arrange:
+			//   - Create a FinBackup that is StoredToNode and Verified.
+			//   - Create a FinRestore targeting the FinBackup.
+			//
+			// Act:
+			//   - Reconcile to create restore PVC.
+			//   - Bind restore PVC to PV.
+			//   - Reconcile to create restore Job.
+			//   - Make restore Job fail with exit code 4.
+			//   - Reconcile after job failure.
+			//
+			// Assert:
+			//   - The FinBackup has MetadataCorrupted=True condition.
+
+			// Arrange
+			By("creating a FinBackup that is StoredToNode and Verified")
+			finbackup := CreateFinBackupStoredAndVerified(ctx, k8sClient, workNamespace, utils.GetUniqueName("test-fin-backup"), pvc, 1, utils.GetUniqueName("test-node"))
+
+			By("creating a FinRestore targeting the FinBackup")
+			finrestore := NewFinRestore(
+				workNamespace,
+				utils.GetUniqueName("test-restore"),
+				finbackup.Name,
+				utils.GetUniqueName("restore-pvc"),
+				userNamespace,
+			)
+			Expect(k8sClient.Create(ctx, finrestore)).Should(Succeed())
+
+			// Act
+			By("reconciling to create restore PVC")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finrestore)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("binding the restore PVC to a PV")
+			createAndBindRestorePV(ctx, finrestore)
+
+			By("reconciling to create restore Job")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finrestore)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("making the restore Job fail with exit code 4")
+			makeJobFailWithExitCode(ctx, restoreJobName(finrestore), 4)
+
+			By("reconciling after job failure")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finrestore)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert
+			By("checking the FinBackup has MetadataCorrupted=True condition")
+			var updatedBackup finv1.FinBackup
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(finbackup), &updatedBackup)).Should(Succeed())
+			Expect(updatedBackup.IsMetadataCorrupted()).Should(BeTrue())
+		})
+
+		It("should not create restore Job when FinBackup has MetadataCorrupted=True", func(ctx SpecContext) {
+			// Description:
+			//   Ensure that when a FinBackup has MetadataCorrupted=True,
+			//   the reconciler skips creating a restore Job.
+			//
+			// Arrange:
+			//   - Create a FinBackup with MetadataCorrupted=True.
+			//   - Create a FinRestore targeting the FinBackup.
+			//
+			// Act:
+			//   - Reconcile the FinRestore.
+			//
+			// Assert:
+			//   - No restore Job is created.
+
+			// Arrange
+			By("creating a FinBackup with MetadataCorrupted=True")
+			finbackup := CreateFinBackupStoredAndVerified(ctx, k8sClient, workNamespace, utils.GetUniqueName("test-fin-backup"), pvc, 1, utils.GetUniqueName("test-node"))
+			meta.SetStatusCondition(&finbackup.Status.Conditions, metav1.Condition{
+				Type:    finv1.BackupConditionMetadataCorrupted,
+				Status:  metav1.ConditionTrue,
+				Reason:  "MetadataCorrupted",
+				Message: "fin.sqlite3 corruption detected",
+			})
+			Expect(k8sClient.Status().Update(ctx, finbackup)).Should(Succeed())
+
+			By("creating a FinRestore targeting the FinBackup")
+			finrestore := NewFinRestore(
+				workNamespace,
+				utils.GetUniqueName("test-restore"),
+				finbackup.Name,
+				utils.GetUniqueName("restore-pvc"),
+				userNamespace,
+			)
+			Expect(k8sClient.Create(ctx, finrestore)).Should(Succeed())
+
+			// Act
+			By("reconciling the FinRestore")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(finrestore)})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert
+			By("checking no restore Job is created")
+			ExpectNoJob(ctx, k8sClient, restoreJobName(finrestore), cephNamespace)
+		})
+	})
+
 	Context("Behavior of allowUnverified field", func() {
 		var pvc *corev1.PersistentVolumeClaim
 

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -57,6 +57,7 @@ const (
 	JobStatusFailedWithExitCode1
 	JobStatusFailedWithExitCode2
 	JobStatusFailedWithExitCode3
+	JobStatusFailedWithExitCode4
 	JobStatusUnknown
 )
 
@@ -118,6 +119,8 @@ func CheckJobStatus(
 		status = JobStatusFailedWithExitCode2
 	case 3:
 		status = JobStatusFailedWithExitCode3
+	case 4:
+		status = JobStatusFailedWithExitCode4
 	default:
 		status = JobStatusUnknown
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cybozu-go/fin/cmd"
 	"github.com/cybozu-go/fin/internal/infrastructure/ceph"
+	"github.com/cybozu-go/fin/internal/infrastructure/db"
 	"github.com/cybozu-go/fin/internal/job/verification"
 )
 
@@ -14,6 +15,8 @@ func main() {
 	if err := cmd.Execute(); err != nil {
 		slog.Error("failed to execute command", "error", err)
 		switch {
+		case errors.Is(err, db.ErrDBCorrupted):
+			os.Exit(4)
 		case errors.Is(err, verification.ErrFsckFailed):
 			os.Exit(3)
 		case errors.Is(err, ceph.ErrChecksumMismatch):


### PR DESCRIPTION

This PR follows #241 and adds the Kubernetes-layer handling for fin.sqlite3
corruption. #241 made the db layer surface corruption as db.ErrDBCorrupted; this
PR wires that through to the job exit code, a new FinBackup condition, and the
controllers.

Job commands that hit db.ErrDBCorrupted now exit with code 4, which
distinguishes fin.sqlite3 corruption from other failures (1: generic, 2:
backup data checksum mismatch, 3: fsck failure, 4: fin.sqlite3 corruption).

A new MetadataCorrupted condition is added to FinBackup. When a job exits with
code 4, the controller sets MetadataCorrupted=True on the FinBackup and stops
all further reconciliation. Unlike ChecksumMismatched, there is no override
annotation, because operating on a corrupted metadata store makes any
subsequent operation's outcome unpredictable. 

The cleanup job previously had neither a PodFailurePolicy nor exit-code-aware
status handling, so both are added (and its RestartPolicy is changed to Never,
as required when a PodFailurePolicy is set).