### PR TITLE
e2e: align toolbox ceph image with cluster version

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -57,6 +57,7 @@ To change their versions, edit `versions.mk`.
 - [minikube](https://github.com/kubernetes/minikube/releases)
 - [Rook](https://github.com/rook/rook/releases)
 - [golangci-lint](https://github.com/golangci/golangci-lint/releases)
+- [Ceph](https://quay.io/repository/ceph/ceph?tab=tags)
 
 Some operators are described in `test/utils/utils.go`. Please check their versions and update them, if necessary. Note that it should use the LTS version for cert-manager.
 
@@ -66,10 +67,6 @@ Some operators are described in `test/utils/utils.go`. Please check their versio
 Update the following version in Dockerfile, if necessary, too:
 
 - custom rbd-export-diff
-
-The Ceph version is described in the following file:
-
-- `test/e2e/testdata/values-cluster.yaml`
 
 #### Depending modules
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -125,7 +125,8 @@ launch-rook-ceph: create-loop-dev $(KUBECTL) $(HELM)
 		-e "s%{NODE_NAME}%$(MINIKUBE_PROFILE_NAME)%" \
 		testdata/persistentvolumes-template.yaml | \
 		$(KUBECTL) apply -f -
-	$(HELM) upgrade --install --version $(ROOK_CHART_VERSION) --repo https://charts.rook.io/release --namespace $(NS) rook-ceph-cluster rook-ceph-cluster -f testdata/values-cluster.yaml --wait
+	CEPH_IMAGE_VERSION=$(CEPH_IMAGE_VERSION) envsubst < testdata/values-cluster.yaml | \
+		$(HELM) upgrade --install --version $(ROOK_CHART_VERSION) --repo https://charts.rook.io/release --namespace $(NS) rook-ceph-cluster rook-ceph-cluster -f - --wait
 	$(MAKE) wait-deploy-ready NS=$(NS) DEPLOY=rook-ceph-operator
 	$(MAKE) wait-deploy-ready NS=$(NS) DEPLOY=rook-ceph-osd-0
 	$(KUBECTL) apply -f testdata/cephblockpool.yaml

--- a/test/e2e/testdata/values-cluster.yaml
+++ b/test/e2e/testdata/values-cluster.yaml
@@ -6,7 +6,7 @@ cephObjectStores: []
 
 toolbox:
   enabled: true
-  image: quay.io/ceph/ceph:v19.2.2
+  image: quay.io/ceph/ceph:${CEPH_IMAGE_VERSION}
   resources: null
 
 cephClusterSpec:
@@ -15,7 +15,7 @@ cephClusterSpec:
     count: 1
     allowMultiplePerNode: false
   cephVersion:
-    image: quay.io/ceph/ceph:v19.2.2
+    image: quay.io/ceph/ceph:${CEPH_IMAGE_VERSION}
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/test/e2e/testdata/values-cluster.yaml
+++ b/test/e2e/testdata/values-cluster.yaml
@@ -6,6 +6,7 @@ cephObjectStores: []
 
 toolbox:
   enabled: true
+  image: quay.io/ceph/ceph:v19.2.2
   resources: null
 
 cephClusterSpec:

--- a/versions.mk
+++ b/versions.mk
@@ -6,6 +6,8 @@ KUBERNETES_VERSION ?= 1.35.4
 MINIKUBE_VERSION := v1.38.1
 # https://github.com/rook/rook/releases
 ROOK_CHART_VERSION := v1.19.5
+# https://quay.io/repository/ceph/ceph
+CEPH_IMAGE_VERSION := v19.2.2
 # https://github.com/kubernetes-sigs/kustomize/releases
 KUSTOMIZE_VERSION := v5.8.1
 # https://github.com/kubernetes-sigs/controller-tools/releases


### PR DESCRIPTION
### Problem

The rook-ceph-cluster Helm chart deploys the toolbox using its own default ceph image quay.io/ceph/ceph:v19.2.3, which differs from the version configured for CephCluster. This caused an unnecessary ~1.46 GB image pull on every CI run.

```
# Events
LAST SEEN   TYPE      REASON   OBJECT                               SUBOBJECT                        SOURCE                  MESSAGE                                                                                                FIRST SEEN   COUNT   NAME
64s         Normal    Pulled   pod/rook-ceph-osd-0-59c9f686bf-xn9vq spec.containers{osd}             kubelet, fin-test       Container image "quay.io/ceph/ceph:v19.2.2" already present on machine and can be accessed by the pod  64s          1       rook-ceph-osd-0-59c9f686bf-xn9vq.18b76b8e339388e0
2m          Normal    Pulling  pod/rook-ceph-tools-85bd488b6-w5rkr  spec.containers{rook-ceph-tools} kubelet, fin-test-m02   Pulling image "quay.io/ceph/ceph:v19.2.3"                                                              2m           1       rook-ceph-tools-85bd488b6-w5rkr.18b76b8134fc905a                       
```

### Changes

- Set `toolbox.image` in `values-cluster.yaml` to `${CEPH_IMAGE_VERSION}` so the toolbox uses the same image as the cluster.
- Pin `CEPH_IMAGE_VERSION` in `versions.mk` to consolidate the version definition in one place.
