### PR TITLE
e2e: cache custom-ceph stage across branches with actions/cache

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,14 +45,42 @@ jobs:
       - uses: ./.github/actions/set-up-kvm-for-e2e-tests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Build and push Docker image with cache
+
+      # The custom-ceph stage is expensive but rarely changes, so cache it using
+      # the Dockerfile hash. The key is branch-independent, meaning an entry
+      # created on the main branch can be restored from any pull request.
+      - name: Restore custom-ceph cache
+        id: cache-custom-ceph
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/custom-ceph-cache
+          key: custom-ceph-${{ hashFiles('Dockerfile') }}
+
+      - name: Build custom-ceph stage
+        if: steps.cache-custom-ceph.outputs.cache-hit != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: custom-ceph
+          cache-to: type=local,dest=/tmp/custom-ceph-cache
+
+      # Only main saves the cache: a PR-saved cache cannot be restored by
+      # other branches anyway, and not saving prevents cache poisoning.
+      - name: Save custom-ceph cache
+        if: github.ref == 'refs/heads/main' && steps.cache-custom-ceph.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/custom-ceph-cache
+          key: custom-ceph-${{ hashFiles('Dockerfile') }}
+
+      - name: Build Docker image with cache
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           tags: controller:latest
           load: true
-          cache-from: type=gha,scope=${{ github.ref_name }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}
+          cache-from: type=local,src=/tmp/custom-ceph-cache
 
       - name: Setup minikube with kvm2 driver
         run: |


### PR DESCRIPTION
### Problem

The image build caches every layer through BuildKit's GitHub Actions cache backend.

refs: https://github.com/cybozu-go/fin/actions/caches

```yaml
cache-from: type=gha,scope=${{ github.ref_name }}
cache-to:   type=gha,mode=max,scope=${{ github.ref_name }}
```

- `mode=max` exports every intermediate layer on each run, including the `builder` stage.  Since the Go source changes often, so those layers are uploaded repeatedly while rarely being reused. They also fill the repository's 10 GB cache limit, and eviction then drops the one layer worth keeping: `custom-ceph`.
- `scope=${{ github.ref_name }}` isolates the cache per ref. For a pull request,  `ref_name` is `<number>/merge`, so a pull request cannot see the cache written  on main and rebuilds `custom-ceph` from scratch.

### Solution

Cache only the `custom-ceph` stage, keyed on the Dockerfile hash. The key is branch-independent, so an entry created on main can be restored by any pull request.

<img width="921" height="291" alt="スクリーンショット 2026-07-17 23 50 13" src="https://github.com/user-attachments/assets/6fe7224f-f343-417d-ab6f-92a3d7286284" />


Split the cache into `actions/cache/restore` and `actions/cache/save`, and run the save step only on main. A cache saved from a pull request is scoped to `refs/pull/<n>/merge` and cannot be restored anywhere else, so saving it only consumes storage. It also means an untrusted pull request cannot write a cache that main will later read.

The `builder` stage is no longer cached. A pull request that leaves the Go source untouched now pays the ~94s build it used to skip, in exchange for:

- no full-layer export on every run
- `custom-ceph` surviving instead of being evicted, which saves ~107s on the first run of every pull request