### PR TITLE
e2e: use K8s v1.35.1 supported by the minikube in use

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,7 +33,7 @@ jobs:
           - finbackupconfig
         kubernetes-version:
           - "1.34.4"
-          - "1.35.4"
+          - "1.35.1"
     env:
       KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
     steps:

--- a/versions.mk
+++ b/versions.mk
@@ -1,7 +1,9 @@
 # https://github.com/helm/helm/releases
 HELM_VERSION := 4.2.0
 # It is set by CI using the environment variable, use conditional assignment.
-KUBERNETES_VERSION ?= 1.35.4
+# Use a Kubernetes version supported by the minikube version below.
+# The patch version may differ from the k8s patch version in go.mod.
+KUBERNETES_VERSION ?= 1.35.1
 # https://github.com/kubernetes/minikube/releases
 MINIKUBE_VERSION := v1.38.1
 # https://github.com/rook/rook/releases


### PR DESCRIPTION
[Minikube v1.38.1](https://github.com/kubernetes/minikube/releases/tag/v1.38.1) supports Kubernetes up to v1.35.1 as its latest version.