### PR TITLE
test: lengthen timeout to avoid unstable behaviour 2

### DIFF
--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -449,7 +449,7 @@ var _ = Describe("FinBackup Controller integration test", Ordered, func() {
 				var job batchv1.Job
 				key := client.ObjectKey{Namespace: cephNamespace, Name: backupJobName(smallestFB)}
 				g.Expect(k8sClient.Get(ctx, key, &job)).To(Succeed())
-			}, "5s", "1s").Should(Succeed())
+			}, "10s", "1s").Should(Succeed())
 
 			By("verifying no backup job exists for the FinBackup with the larger SnapID")
 			Consistently(func(g Gomega) {


### PR DESCRIPTION
It fixed flakiness for CSATEST-1505
similar to 38fa74ca12c0af1754860e4e8d61746e4685e8c0 https://github.com/cybozu-go/fin/pull/221