### PR TITLE
test: address CI flakiness

### DIFF
--- a/internal/controller/finbackup_controller_test.go
+++ b/internal/controller/finbackup_controller_test.go
@@ -2258,7 +2258,7 @@ func waitFinBackupCreateStatus(pvcNamespace, pvcName, kind string, expected floa
 		value, err := gatherBackupCreateStatus(pvcNamespace, pvcName, kind)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(value).To(Equal(expected))
-	}, "1s", "0.1s").Should(Succeed())
+	}, "5s", "0.1s").Should(Succeed())
 }
 
 var _ = Describe("fin_backup_create_status metric", Ordered, func() {


### PR DESCRIPTION
waitFinBackupCreateStatus wait for at most 1s to fill the condition. However, it seems to be too short so CI sometimes fails.

ref.
https://github.com/cybozu-go/fin/actions/runs/27607442984/job/81622912274

Address this flakiness by extending timeout.

```
  STEP: creating a FinBackup @ 06/10/26 07:33:54.649
  STEP: waiting for the fin_backup_create_status metric to be set 1 @ 06/10/26 07:33:54.666
  [FAILED] in [BeforeEach] - /home/runner/work/fin/fin/internal/controller/finbackup_controller_test.go:2021 @ 06/10/26 07:33:55.668
  << Timeline

  [FAILED] Timed out after 1.002s.
  The function passed to Eventually failed at /home/runner/work/fin/fin/internal/controller/finbackup_controller_test.go:1952 with:
  Unexpected error:
      <*errors.errorString | 0xc0027290d0>:
      metric not found
      {
          s: "metric not found",
      }
  occurred
  In [BeforeEach] at: /home/runner/work/fin/fin/internal/controller/finbackup_controller_test.go:2021
```