### PR TITLE
e2e: simplify disk handling for single-disk runners

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,10 +16,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Github runner's extra disk is mounted on the /mnt directory.
-  MINIKUBE_HOME: "/mnt/"
-
 jobs:
   build:
     runs-on: "ubuntu-22.04"
@@ -47,10 +43,6 @@ jobs:
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/.ghcup /usr/local/lib/android
           df -h /
-
-      - name: Make /mnt accessible from `runner` user
-        run: |
-          sudo chown runner:runner /mnt
 
       - uses: ./.github/actions/set-up-kvm-for-e2e-tests
       - name: Set up Docker Buildx

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,12 +38,6 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Free up disk space
-        run: |
-          df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/.ghcup /usr/local/lib/android
-          df -h /
-
       - uses: ./.github/actions/set-up-kvm-for-e2e-tests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
#### Problem

The e2e workflow was tuned for the old GitHub-hosted runner layout, which was made up of a root disk and a separate ephemeral disk mounted at `/mnt`. GitHub is now moving its hosted runners to a single 146G disk, so the free-up-disk-space step is no longer needed. On top of that, the step can take several minutes depending on IO.


refs:
- About a single disk layout
    - https://github.com/actions/runner-images/issues/13587#issuecomment-3801230871. 
- The free-up-disk-space takes several minutes.
    - 54s https://github.com/cybozu-go/fin/actions/runs/27205429685/job/80324454097
    - 3m29s https://github.com/cybozu-go/fin/actions/runs/26145952848/job/76901443894

#### Solution

- Stop using `/mnt`, as it is just a directory on the root disk.
- Drop the free-up-disk-space step, which is unnecessary since ~87G is free before it runs but takes minutes.


refs
- Output of `df -h /`
    - https://github.com/cybozu-go/fin/actions/runs/28211342543/job/83573276515