### PR TITLE
job: correct lock failure correctly

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cybozu-go/fin/internal/job"
 	"github.com/cybozu-go/fin/internal/job/backup"
 	"github.com/cybozu-go/fin/internal/job/input"
-	"github.com/cybozu-go/fin/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -151,7 +150,7 @@ func backupJobMain() error {
 			slog.Info("Backup job completed successfully")
 			return nil
 		}
-		if !errors.Is(err, model.ErrBusy) {
+		if !errors.Is(err, job.ErrCantLock) {
 			return fmt.Errorf("failed to perform backup: %w", err)
 		}
 		slog.Warn("failed to acquire lock, will retry.")

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cybozu-go/fin/internal/job"
 	"github.com/cybozu-go/fin/internal/job/cleanup"
 	"github.com/cybozu-go/fin/internal/job/input"
-	"github.com/cybozu-go/fin/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -82,7 +81,7 @@ func cleanupJobMain() error {
 			slog.Info("Cleanup job completed successfully")
 			return nil
 		}
-		if !errors.Is(err, model.ErrBusy) {
+		if !errors.Is(err, job.ErrCantLock) {
 			return fmt.Errorf("failed to perform cleanup: %w", err)
 		}
 		slog.Warn("failed to acquire lock, will retry.")

--- a/cmd/deletion.go
+++ b/cmd/deletion.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cybozu-go/fin/internal/job"
 	"github.com/cybozu-go/fin/internal/job/deletion"
 	"github.com/cybozu-go/fin/internal/job/input"
-	"github.com/cybozu-go/fin/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -97,7 +96,7 @@ func deletionJobMain() error {
 			slog.Info("Deletion job completed successfully")
 			return nil
 		}
-		if !errors.Is(err, model.ErrBusy) {
+		if !errors.Is(err, job.ErrCantLock) {
 			return fmt.Errorf("failed to perform deletion: %w", err)
 		}
 		slog.Warn("failed to acquire lock, will retry.")

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cybozu-go/fin/internal/job"
 	"github.com/cybozu-go/fin/internal/job/input"
 	"github.com/cybozu-go/fin/internal/job/restore"
-	"github.com/cybozu-go/fin/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -106,7 +105,7 @@ func restoreJobMain() error {
 			slog.Info("restore job completed successfully")
 			return nil
 		}
-		if !errors.Is(err, model.ErrBusy) {
+		if !errors.Is(err, job.ErrCantLock) {
 			return fmt.Errorf("failed to perform restore: %w", err)
 		}
 		slog.Warn("failed to acquire lock, will retry.")


### PR DESCRIPTION
Each job' Perform() function returns job.ErrCantLock on lock failure. So we check this error rather than model.ErrBusy.