### PR TITLE
ISSUE_TEMPLATE: add kubebuilder to the TODO list

### DIFF
--- a/.github/ISSUE_TEMPLATE/update_supporting_kubernetes.md
+++ b/.github/ISSUE_TEMPLATE/update_supporting_kubernetes.md
@@ -26,6 +26,8 @@ Must update Kubernetes with each new version of Kubernetes.
 - [ ] rook
   - https://github.com/rook/rook/releases
   - Only need to confirm that upstream Rook has released a version that supports the target Kubernetes version.
+- [ ] kubebuilder
+  - https://github.com/kubernetes-sigs/kubebuilder/releases
 
 ### Additional Checks
 


### PR DESCRIPTION
The kubebuilder version compatible with the new Kubernetes version is
now required in the maintenance.md.